### PR TITLE
Load .env automatically for ngrok token

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 - `fastmcp`
 - `httpx`
 - `Pillow`
+- `python-dotenv`
 - Anki с установленным плагином [AnkiConnect](https://foosoft.net/projects/anki-connect/) и запущенным Anki-клиентом
 
 ## Требования к ngrok
@@ -18,9 +19,10 @@
 
 ## Пошаговый сценарий
 1. **Подготовка окружения**
-   - Установите зависимости: `pip install fastmcp httpx Pillow`.
+   - Установите зависимости: `pip install fastmcp httpx Pillow python-dotenv`.
    - Убедитесь, что Anki запущен, а расширение AnkiConnect активно.
    - Скопируйте `.env`-шаблон: `cp env.example .env` и впишите значение `NGROK_AUTHTOKEN=<ваш_токен>`.
+     `.env` подхватывается автоматически через `python-dotenv`, поэтому дополнительных команд не требуется.
    - Поместите `ngrok` рядом с проектом или добавьте в `PATH`.
 2. **Запуск**
    - Выполните команду `python main.py`.

--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ import threading
 from pathlib import Path
 
 import requests
+from dotenv import load_dotenv
 
 PORT = 8000
 MCP_CMD = [
@@ -26,21 +27,7 @@ MCP_CMD = [
 NGROK_API = "http://127.0.0.1:4040/api/tunnels"
 
 
-def load_env(path: Path) -> dict[str, str]:
-    env_data: dict[str, str] = {}
-    try:
-        with path.open("r", encoding="utf-8") as fh:
-            for raw_line in fh:
-                line = raw_line.strip()
-                if not line or line.startswith("#"):
-                    continue
-                if "=" not in line:
-                    continue
-                key, value = line.split("=", 1)
-                env_data[key.strip()] = value.strip()
-    except FileNotFoundError:
-        pass
-    return env_data
+load_dotenv()
 
 procs = []  # [(name, Popen)]
 _output_state = {}
@@ -241,10 +228,7 @@ if __name__ == "__main__":
             shutdown()
             sys.exit(1)
 
-        env_map = load_env(Path(".env"))
-        token = env_map.get("NGROK_AUTHTOKEN", "").strip()
-        if not token:
-            token = os.environ.get("NGROK_AUTHTOKEN", "").strip()
+        token = os.environ.get("NGROK_AUTHTOKEN", "").strip()
 
         NGROK_CMD = [ngrok_exe, "http", str(PORT)]
         popen_env = None


### PR DESCRIPTION
## Summary
- load environment variables from `.env` via python-dotenv during startup
- ensure ngrok inherits the NGROK_AUTHTOKEN value when available
- document the python-dotenv dependency and automatic `.env` loading in the README

## Testing
- python -m compileall main.py server.py test_client.py

------
https://chatgpt.com/codex/tasks/task_e_68ce80113e088330a06c1f15592b26ff