### PR TITLE
Expose MCP manifest endpoints

### DIFF
--- a/tests/test_manifest_routes.py
+++ b/tests/test_manifest_routes.py
@@ -1,0 +1,23 @@
+import pytest
+from fastapi.testclient import TestClient
+
+pytest.importorskip("fastmcp")
+
+import server
+
+
+@pytest.fixture(scope="module")
+def client():
+    return TestClient(server.app.http_app())
+
+
+@pytest.mark.parametrize("path", ["/", "/.well-known/mcp.json"])
+def test_manifest_endpoints_return_manifest_json(client, path):
+    response = client.get(path)
+
+    assert response.status_code == 200
+    assert response.headers.get("content-type", "").startswith("application/json")
+
+    payload = response.json()
+    for key in ("mcp", "server", "tools"):
+        assert key in payload


### PR DESCRIPTION
## Summary
- add HTTP manifest endpoints at `/` and `/.well-known/mcp.json` using the FastMCP custom routing API
- normalize the generated manifest so it always exposes the spec-required `mcp`, `server`, and `tools` keys
- extend the image resize test shims to tolerate missing dependencies and add coverage for the new manifest endpoints

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68ce864c2a3c83309b506fbf43a0a339