### PR TITLE
Handle redirects when fetching images

### DIFF
--- a/server.py
+++ b/server.py
@@ -72,7 +72,7 @@ async def store_media_file(filename: str, data_b64: str):
 
 
 async def fetch_image_as_base64(url: str, max_side: int) -> str:
-    async with httpx.AsyncClient(timeout=30) as c:
+    async with httpx.AsyncClient(timeout=30, follow_redirects=True) as c:
         r = await c.get(url)
         r.raise_for_status()
         content = r.content

--- a/tests/test_fetch_image_resize.py
+++ b/tests/test_fetch_image_resize.py
@@ -1,4 +1,5 @@
 import asyncio
+import base64
 import sys
 import types
 from io import BytesIO
@@ -36,11 +37,14 @@ import server
 
 
 class DummyResponse:
-    def __init__(self, content: bytes):
+    def __init__(self, content: bytes, status_code: int = 200, headers: dict | None = None):
         self.content = content
+        self.status_code = status_code
+        self.headers = headers or {}
 
     def raise_for_status(self):
-        return None
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP error {self.status_code}")
 
 
 class DummyAsyncClient:
@@ -55,6 +59,33 @@ class DummyAsyncClient:
 
     async def get(self, url: str):
         return self._response
+
+
+class DummyRedirectAsyncClient:
+    def __init__(self, initial_url: str, redirect_url: str, final_response: DummyResponse):
+        self.initial_url = initial_url
+        self.redirect_url = redirect_url
+        self.final_response = final_response
+        self.follow_redirects = False
+        self.requested_urls: list[str] = []
+        self._responses = [
+            DummyResponse(b"", status_code=302, headers={"Location": redirect_url}),
+            final_response,
+        ]
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def get(self, url: str):
+        self.requested_urls.append(url)
+        response = self._responses.pop(0)
+        if response.status_code == 302 and self.follow_redirects:
+            location = response.headers["Location"]
+            return await self.get(location)
+        return response
 
 
 def test_fetch_image_handles_extremely_thin_image(monkeypatch):
@@ -96,3 +127,23 @@ def test_fetch_image_single_pixel_width_does_not_raise_value_error(monkeypatch):
 
     assert isinstance(result, str)
     assert result
+
+
+def test_fetch_image_follows_redirect_and_returns_final_content(monkeypatch):
+    initial_url = "http://example.com/start.jpg"
+    redirect_url = "http://cdn.example.com/final.jpg"
+    final_payload = b"redirected-bytes"
+    final_response = DummyResponse(final_payload)
+    redirect_client = DummyRedirectAsyncClient(initial_url, redirect_url, final_response)
+
+    def client_factory(*args, **kwargs):
+        redirect_client.follow_redirects = kwargs.get("follow_redirects", False)
+        assert redirect_client.follow_redirects is True
+        return redirect_client
+
+    monkeypatch.setattr(server.httpx, "AsyncClient", client_factory)
+
+    result = asyncio.run(server.fetch_image_as_base64(initial_url, max_side=128))
+
+    assert redirect_client.requested_urls == [initial_url, redirect_url]
+    assert base64.b64decode(result) == final_payload


### PR DESCRIPTION
## Summary
- ensure httpx.AsyncClient used for image fetching follows redirects
- extend image fetch tests with redirect simulation and response handling assertions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce877a6b308330aca16f3fab4cd180