### PR TITLE
Handle data URL images and sanitize payloads

### DIFF
--- a/tests/test_image_data_url.py
+++ b/tests/test_image_data_url.py
@@ -1,0 +1,101 @@
+import base64
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+def _field_stub(*args, **kwargs):  # pragma: no cover - support for missing pydantic
+    if "default" in kwargs:
+        return kwargs["default"]
+    if "default_factory" in kwargs:
+        return kwargs["default_factory"]()
+    return None
+
+
+try:  # pragma: no cover - exercised only when dependency missing
+    import fastmcp as _fastmcp_mod  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - executed in minimal test environments
+    def _noop_decorator(*args, **kwargs):
+        def decorator(func):
+            return func
+
+        return decorator
+
+    fastmcp_stub = types.SimpleNamespace(
+        FastMCP=lambda *args, **kwargs: types.SimpleNamespace(
+            tool=_noop_decorator,
+            custom_route=_noop_decorator,
+            name=kwargs.get("name", args[0] if args else "anki-mcp"),
+        )
+    )
+    sys.modules.setdefault("fastmcp", fastmcp_stub)
+
+try:  # pragma: no cover - exercised only when dependency missing
+    import pydantic as _pydantic_mod  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - executed in minimal test environments
+    pydantic_stub = types.SimpleNamespace(
+        BaseModel=object,
+        Field=_field_stub,
+        constr=lambda **kwargs: str,
+        AnyHttpUrl=str,
+    )
+    sys.modules.setdefault("pydantic", pydantic_stub)
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import server
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+class DummyUUID:
+    def __init__(self, hex_value: str):
+        self.hex = hex_value
+
+
+@pytest.mark.anyio
+async def test_add_from_model_sanitizes_data_url(monkeypatch):
+    raw_bytes = b"png-payload"
+    original_b64 = base64.b64encode(raw_bytes).decode("ascii")
+    data_url = f"  data:image/png;base64,{original_b64}  "
+
+    stored: dict[str, str] = {}
+
+    async def fake_store_media_file(filename: str, data_b64: str):
+        stored["filename"] = filename
+        stored["data"] = data_b64
+
+    async def fake_anki_call(action: str, params: dict):
+        if action == "createDeck":
+            return True
+        if action == "modelFieldNames":
+            return ["Front", "Back"]
+        if action == "modelTemplates":
+            return {"Card 1": {"Front": "{{Front}}", "Back": "{{Back}}"}}
+        if action == "modelStyling":
+            return {"css": ""}
+        if action == "addNotes":
+            return [123]
+        raise AssertionError(f"unexpected action: {action}")
+
+    monkeypatch.setattr(server, "store_media_file", fake_store_media_file)
+    monkeypatch.setattr(server, "anki_call", fake_anki_call)
+    monkeypatch.setattr(server.uuid, "uuid4", lambda: DummyUUID("abc123"))
+
+    image = server.ImageSpec(image_base64=data_url, target_field="Back")
+    note = server.NoteInput(fields={"Front": "Question"}, images=[image])
+
+    result = await server.add_from_model.fn("Default", "Basic", [note])
+
+    assert stored["data"] == base64.b64encode(raw_bytes).decode("ascii")
+    assert stored["filename"] == "abc123.png"
+    assert result.added == 1
+    assert all("note is empty" not in str(detail) for detail in result.details)
+


### PR DESCRIPTION
## Summary
- add a sanitize_image_payload helper to normalize inline data URLs and reuse the decoded media when saving fields
- validate image payloads inside add_from_model/add_notes, emit informative warnings, and honor suggested file extensions when no filename is provided
- add coverage for data URL image uploads and update existing async tests to call the underlying tool functions when FastMCP is present

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce8aadd39c8330ab271034119a4784