### PR TITLE
Handle whitespace in data URLs and add tests

### DIFF
--- a/server.py
+++ b/server.py
@@ -199,7 +199,7 @@ def ensure_img_tag(existing: str, fname: str) -> str:
     return (existing or "") + ("\n\n" if existing else "") + tag
 
 
-DATA_URL_RE = re.compile(r"^data:image/([a-zA-Z0-9+.\-]+);base64,(.+)$")
+DATA_URL_RE = re.compile(r"^data:image/([a-zA-Z0-9+.\-]+);base64,(.+)$", re.DOTALL)
 
 
 def ext_from_mime(mime_subtype: str) -> str:
@@ -231,7 +231,8 @@ async def process_data_urls_in_fields(fields: Dict[str, str], results: List[dict
         mime_subtype, b64 = m.group(1), m.group(2)
         try:
             # нормализуем, валидируем base64
-            raw = base64.b64decode(b64, validate=True)
+            b64_clean = re.sub(r"\s+", "", b64)
+            raw = base64.b64decode(b64_clean, validate=True)
             # имя по хэшу содержимого
             digest = hashlib.sha1(raw).hexdigest()  # компактно и детерминировано
             fname = f"img_{digest}.{ext_from_mime(mime_subtype)}"

--- a/tests/_fastmcp_stub.py
+++ b/tests/_fastmcp_stub.py
@@ -1,0 +1,45 @@
+import sys
+import types
+from typing import Iterable, Optional
+
+try:  # pragma: no cover - используем FastAPI, если доступен
+    from fastapi import FastAPI
+except Exception:  # pragma: no cover - в деградированном окружении маршруты не нужны
+    FastAPI = None  # type: ignore
+
+
+class FakeFastMCP:
+    """Минимальный стаб FastMCP для unit-тестов без зависимости от fastmcp."""
+
+    def __init__(self, *args, **kwargs):
+        self.name = args[0] if args else "anki-mcp"
+        self._app = FastAPI() if FastAPI is not None else None
+
+    def tool(self, *args, **kwargs):
+        def decorator(func):
+            return func
+
+        return decorator
+
+    def custom_route(self, path: str, methods: Optional[Iterable[str]] = None, *args, **kwargs):
+        def decorator(func):
+            if self._app is not None:
+                route_methods = list(methods or ["GET"])
+                self._app.add_api_route(path, func, methods=route_methods)
+            return func
+
+        return decorator
+
+    def http_app(self):
+        if self._app is None:
+            raise AttributeError("http_app unavailable in stub")
+        return self._app
+
+
+def ensure_stub_installed():
+    module = types.ModuleType("fastmcp")
+    module.FastMCP = FakeFastMCP
+    sys.modules["fastmcp"] = module
+
+
+__all__ = ["ensure_stub_installed", "FakeFastMCP"]

--- a/tests/test_dedup_key.py
+++ b/tests/test_dedup_key.py
@@ -1,22 +1,11 @@
 import sys
-import types
 from pathlib import Path
 
 import pytest
 
+from _fastmcp_stub import ensure_stub_installed
 
-class _FakeFastMCP:
-    def __init__(self, *args, **kwargs):
-        pass
-
-    def tool(self, *args, **kwargs):
-        def decorator(func):
-            return func
-
-        return decorator
-
-
-sys.modules.setdefault("fastmcp", types.ModuleType("fastmcp")).FastMCP = _FakeFastMCP
+ensure_stub_installed()
 
 ROOT = Path(__file__).resolve().parent.parent
 if str(ROOT) not in sys.path:

--- a/tests/test_process_data_urls.py
+++ b/tests/test_process_data_urls.py
@@ -1,0 +1,46 @@
+import base64
+import hashlib
+import sys
+from pathlib import Path
+
+import pytest
+
+from _fastmcp_stub import ensure_stub_installed
+
+ensure_stub_installed()
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import server
+
+
+@pytest.mark.asyncio
+async def test_process_data_url_with_newlines(monkeypatch):
+    raw = b"test-image-bytes"
+    b64 = base64.b64encode(raw).decode("ascii")
+    # вставляем перевод строки в base64
+    b64_with_newlines = b64[:5] + "\n" + b64[5:10] + "\n" + b64[10:]
+    data_url = f"data:image/png;base64,{b64_with_newlines}"
+
+    fields = {"Image": data_url}
+    results: list[dict] = []
+
+    stored = {}
+
+    async def fake_store_media_file(filename: str, data_b64: str):
+        stored["filename"] = filename
+        stored["data"] = data_b64
+
+    monkeypatch.setattr(server, "store_media_file", fake_store_media_file)
+
+    await server.process_data_urls_in_fields(fields, results, note_index=0)
+
+    digest = hashlib.sha1(raw).hexdigest()
+    expected_fname = f"img_{digest}.png"
+
+    assert fields["Image"] == expected_fname
+    assert stored["filename"] == expected_fname
+    assert stored["data"] == base64.b64encode(raw).decode("ascii")
+    assert results == [{"index": 0, "info": f"data_url_saved:Image->{expected_fname}"}]


### PR DESCRIPTION
## Summary
- strip whitespace from data URL payloads before decoding and allow multiline matches
- provide a shared FastMCP stub for tests and update existing coverage to use it
- add a regression test ensuring data URLs with embedded newlines are processed and stored

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce8c2ecd0c8330a06cabc14824d79e