### PR TITLE
Ensure MCP spawns from project root

### DIFF
--- a/main.py
+++ b/main.py
@@ -106,7 +106,7 @@ def find_ngrok_exe() -> str:
     )
 
 
-def start(cmd, name, *, env=None):
+def start(cmd, name, *, env=None, cwd=None):
     print(f"[start] {name}: {' '.join(map(str, cmd))}")
     try:
         p = subprocess.Popen(
@@ -120,6 +120,7 @@ def start(cmd, name, *, env=None):
             if os.name == "nt"
             else 0,
             env=env,
+            cwd=cwd,
         )
     except FileNotFoundError as e:
         print(f"[error] Не найден исполняемый файл для {name}: {e}")
@@ -216,7 +217,7 @@ def shutdown():
 
 if __name__ == "__main__":
     # 1) MCP-сервер
-    mcp = start(MCP_CMD, "mcp")
+    mcp = start(MCP_CMD, "mcp", cwd=ROOT)
     time.sleep(0.8)
     tail("mcp", mcp)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+import sys
+import types
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+if "requests" not in sys.modules:
+    requests_stub = types.ModuleType("requests")
+    requests_stub.get = lambda *args, **kwargs: None
+    sys.modules["requests"] = requests_stub
+
+if "dotenv" not in sys.modules:
+    dotenv_stub = types.ModuleType("dotenv")
+    dotenv_stub.load_dotenv = lambda *_args, **_kwargs: False
+    sys.modules["dotenv"] = dotenv_stub
+
+import main
+
+
+def test_mcp_process_uses_project_root(monkeypatch, tmp_path):
+    # Меняем рабочий каталог, чтобы эмулировать запуск из другого места
+    monkeypatch.chdir(tmp_path)
+    assert Path.cwd() == tmp_path
+
+    captured = {}
+
+    class DummyProcess:
+        def __init__(self, cmd, **kwargs):
+            captured["cmd"] = cmd
+            captured["kwargs"] = kwargs
+            self.stdout = None
+
+        def poll(self):
+            return None
+
+    monkeypatch.setattr(main, "_start_reader", lambda *args, **kwargs: None)
+    monkeypatch.setattr(main, "procs", [])
+    monkeypatch.setattr(main.subprocess, "Popen", DummyProcess)
+
+    proc = main.start(main.MCP_CMD, "mcp", cwd=main.ROOT)
+
+    assert captured["cmd"] == main.MCP_CMD
+    assert captured["kwargs"].get("cwd") == main.ROOT
+    assert captured["kwargs"].get("env") is None
+    assert proc is not None


### PR DESCRIPTION
## Summary
- ensure the MCP subprocess is spawned with the project root as its working directory
- add a regression test that changes cwd and verifies the MCP start command passes ROOT to subprocess.Popen

## Testing
- pytest tests/test_main.py

------
https://chatgpt.com/codex/tasks/task_e_68ce8f5a071c8330b9dbfb85678b9f00