### PR TITLE
Validate image resizing bounds

### DIFF
--- a/server.py
+++ b/server.py
@@ -183,7 +183,7 @@ class ImageSpec(BaseModel):
     image_url: Optional[AnyHttpUrl] = None
     target_field: constr(strip_whitespace=True, min_length=1) = "Back"
     filename: Optional[str] = None
-    max_side: int = 768  # ресайз по длинной стороне
+    max_side: int = Field(default=768, ge=1)  # ресайз по длинной стороне
 
 
 class NoteInput(BaseModel):
@@ -231,6 +231,9 @@ async def store_media_file(filename: str, data_b64: str):
 
 
 async def fetch_image_as_base64(url: str, max_side: int) -> str:
+    if max_side < 1:
+        raise ValueError("max_side must be at least 1")
+
     async with httpx.AsyncClient(timeout=30, follow_redirects=True) as c:
         r = await c.get(url)
         r.raise_for_status()

--- a/tests/test_fetch_image_resize.py
+++ b/tests/test_fetch_image_resize.py
@@ -164,3 +164,16 @@ def test_fetch_image_follows_redirect_and_returns_final_content(monkeypatch):
 
     assert redirect_client.requested_urls == [initial_url, redirect_url]
     assert base64.b64decode(result) == final_payload
+
+
+def test_fetch_image_with_zero_max_side_raises_value_error(monkeypatch):
+    monkeypatch.setattr(
+        server.httpx,
+        "AsyncClient",
+        lambda *args, **kwargs: pytest.fail("HTTP client should not be used when max_side is invalid"),
+    )
+
+    with pytest.raises(ValueError, match="max_side"):
+        asyncio.run(
+            server.fetch_image_as_base64("http://example.com/image.jpg", max_side=0)
+        )


### PR DESCRIPTION
## Summary
- enforce a minimum value of 1 for `ImageSpec.max_side`
- validate `max_side` in `fetch_image_as_base64` to avoid invalid resize scales
- add a regression test ensuring zero `max_side` raises a clear error

## Testing
- pytest tests/test_fetch_image_resize.py

------
https://chatgpt.com/codex/tasks/task_e_68ce943fb1fc83309082566870467cd8