### PR TITLE
Normalize image target field names

### DIFF
--- a/tests/test_image_data_url.py
+++ b/tests/test_image_data_url.py
@@ -99,3 +99,79 @@ async def test_add_from_model_sanitizes_data_url(monkeypatch):
     assert result.added == 1
     assert all("note is empty" not in str(detail) for detail in result.details)
 
+
+@pytest.mark.anyio
+async def test_add_from_model_target_field_case_insensitive(monkeypatch):
+    stored: dict[str, str] = {}
+    captured_fields: dict[str, str] = {}
+
+    async def fake_store_media_file(filename: str, data_b64: str):
+        stored["filename"] = filename
+        stored["data"] = data_b64
+
+    async def fake_anki_call(action: str, params: dict):
+        if action == "createDeck":
+            return True
+        if action == "modelFieldNames":
+            return ["Front", "Back"]
+        if action == "modelTemplates":
+            return {"Card 1": {"Front": "{{Front}}", "Back": "{{Back}}"}}
+        if action == "modelStyling":
+            return {"css": ""}
+        if action == "addNotes":
+            captured_fields.update(params["notes"][0]["fields"])
+            return [999]
+        raise AssertionError(f"unexpected action: {action}")
+
+    monkeypatch.setattr(server, "store_media_file", fake_store_media_file)
+    monkeypatch.setattr(server, "anki_call", fake_anki_call)
+    monkeypatch.setattr(server.uuid, "uuid4", lambda: DummyUUID("abc123"))
+
+    img_payload = base64.b64encode(b"gif-bytes").decode("ascii")
+    image = server.ImageSpec(image_base64=img_payload, target_field="back")
+    note = server.NoteInput(fields={"Front": "Question"}, images=[image])
+
+    result = await server.add_from_model.fn("Default", "Basic", [note])
+
+    assert captured_fields.get("Back")
+    assert "back" not in captured_fields
+    assert stored["filename"].endswith(".jpg")  # gif -> jpg after sanitize
+    assert result.added == 1
+    assert all("unknown_target_field" not in detail.get("warn", "") for detail in result.details)
+
+
+@pytest.mark.anyio
+async def test_add_from_model_target_field_invalid(monkeypatch):
+    stored: list[str] = []
+
+    async def fake_store_media_file(filename: str, data_b64: str):
+        stored.append(filename)
+
+    async def fake_anki_call(action: str, params: dict):
+        if action == "createDeck":
+            return True
+        if action == "modelFieldNames":
+            return ["Front", "Back"]
+        if action == "modelTemplates":
+            return {"Card 1": {"Front": "{{Front}}", "Back": "{{Back}}"}}
+        if action == "modelStyling":
+            return {"css": ""}
+        if action == "addNotes":
+            return [321]
+        raise AssertionError(f"unexpected action: {action}")
+
+    monkeypatch.setattr(server, "store_media_file", fake_store_media_file)
+    monkeypatch.setattr(server, "anki_call", fake_anki_call)
+    monkeypatch.setattr(server.uuid, "uuid4", lambda: DummyUUID("deadbeef"))
+
+    img_payload = base64.b64encode(b"png-bytes").decode("ascii")
+    image = server.ImageSpec(image_base64=img_payload, target_field="NotAField")
+    note = server.NoteInput(fields={"Front": "Question"}, images=[image])
+
+    result = await server.add_from_model.fn("Default", "Basic", [note])
+
+    assert not stored
+    warn_messages = [detail["warn"] for detail in result.details if "warn" in detail]
+    assert any("unknown_target_field" in msg for msg in warn_messages)
+    assert any("['Front', 'Back']" in msg for msg in warn_messages)
+


### PR DESCRIPTION
## Summary
- map model field names to their canonical casing for fast lookups in `anki.add_from_model`
- use the canonical field name when inserting images and report unknown targets with available options
- extend image handling tests to cover case-insensitive matches and invalid field diagnostics

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68ce9712a2788330a955cdc090c9a56b