### PR TITLE
Handle case-insensitive image target fields

### DIFF
--- a/server.py
+++ b/server.py
@@ -405,6 +405,7 @@ async def add_from_model(deck: str = DEFAULT_DECK, model: str = DEFAULT_MODEL, i
     await anki_call("createDeck", {"deck": deck})
 
     model_fields, _, _ = await get_model_fields_templates(model)
+    canonical_field_map = {field.lower(): field for field in model_fields}
 
     notes_payload: List[dict] = []
     results: List[dict] = []
@@ -449,10 +450,18 @@ async def add_from_model(deck: str = DEFAULT_DECK, model: str = DEFAULT_MODEL, i
                 continue
 
             fname = img.filename or f"{uuid.uuid4().hex}.{ext_hint or 'jpg'}"
+            canonical_target = canonical_field_map.get(img.target_field.lower())
+            if not canonical_target:
+                allowed = ", ".join(repr(name) for name in model_fields)
+                raise ValueError(
+                    "Unknown image target_field "
+                    f"{img.target_field!r} for note index {i}. "
+                    f"Available fields: [{allowed}]"
+                )
             try:
                 await store_media_file(fname, data_b64)
-                prev = fields.get(img.target_field, "")
-                fields[img.target_field] = ensure_img_tag(prev, fname)
+                prev = fields.get(canonical_target, "")
+                fields[canonical_target] = ensure_img_tag(prev, fname)
             except Exception as e:
                 results.append({"index": i, "warn": f"store_media_failed: {e}"})
 


### PR DESCRIPTION
## Summary
- build a canonical field lookup in `anki.add_from_model` so image handling respects model field casing
- raise a descriptive error when an image target field does not exist and reuse canonical names for updates
- extend image data URL tests to cover case-insensitive targets and invalid field diagnostics

## Testing
- pytest tests/test_image_data_url.py

------
https://chatgpt.com/codex/tasks/task_e_68ce97d2de4c8330a0db531d6386902f