### PR TITLE
Handle flat note payloads

### DIFF
--- a/tests/test_add_from_model_unknown_fields.py
+++ b/tests/test_add_from_model_unknown_fields.py
@@ -36,7 +36,7 @@ ROOT = Path(__file__).resolve().parent.parent
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from server import NoteInput, add_from_model
+from server import AddNotesArgs, NoteInput, add_from_model, add_notes
 
 
 @pytest.fixture
@@ -68,3 +68,70 @@ async def test_add_from_model_unknown_fields_raise(monkeypatch):
     assert "Unknown note fields" in message
     assert "'Question'" in message
     assert "'Front'" in message and "'Back'" in message
+
+
+@pytest.mark.anyio
+async def test_add_from_model_accepts_flat_fields(monkeypatch):
+    captured_notes = {}
+
+    async def fake_anki_call(action, params):
+        nonlocal captured_notes
+        if action == "createDeck":
+            return None
+        if action == "modelFieldNames":
+            return ["Front", "Back"]
+        if action == "modelTemplates":
+            return {}
+        if action == "modelStyling":
+            return {"css": ""}
+        if action == "addNotes":
+            captured_notes = params
+            return [555]
+        raise AssertionError(f"Unexpected action: {action}")
+
+    monkeypatch.setattr("server.anki_call", fake_anki_call)
+
+    items = [NoteInput(Front="Question?", Back="Answer!")]
+
+    result = await add_from_model.fn(deck="Deck", model="Basic", items=items)
+
+    assert result.added == 1
+    assert captured_notes["notes"][0]["fields"] == {"Front": "Question?", "Back": "Answer!"}
+    assert captured_notes["notes"][0]["tags"] == []
+
+
+@pytest.mark.anyio
+async def test_add_notes_accepts_flat_fields(monkeypatch):
+    captured_notes = {}
+
+    async def fake_anki_call(action, params):
+        nonlocal captured_notes
+        if action == "createDeck":
+            return None
+        if action == "modelFieldNames":
+            return ["Front", "Back"]
+        if action == "modelTemplates":
+            return {}
+        if action == "modelStyling":
+            return {"css": ""}
+        if action == "addNotes":
+            captured_notes = params
+            return [777]
+        raise AssertionError(f"Unexpected action: {action}")
+
+    monkeypatch.setattr("server.anki_call", fake_anki_call)
+
+    args = AddNotesArgs(deck="Deck", model="Basic", notes=[{"Front": "Q", "Back": "A"}])
+
+    result = await add_notes.fn(args)
+
+    assert result.added == 1
+    assert captured_notes["notes"][0]["fields"] == {"Front": "Q", "Back": "A"}
+    assert captured_notes["notes"][0]["tags"] == []
+
+
+def test_note_input_requires_fields_or_flat_data():
+    with pytest.raises(ValueError) as exc:
+        AddNotesArgs(deck="Deck", model="Basic", notes=[{}])
+
+    assert "Каждый элемент items должен содержать объект fields" in str(exc.value)


### PR DESCRIPTION
## Summary
- normalize NoteInput payloads that omit the `fields` object by moving flat note keys under `fields` while preserving reserved keys
- raise a clear validation error when neither `fields` nor note content is provided
- add regression tests covering flat payloads for `add_from_model`/`add_notes`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf0967727483308c8874e1a59e4cfe