### PR TITLE
Allow add_from_model to accept plain dict items

### DIFF
--- a/tests/test_add_from_model_unknown_fields.py
+++ b/tests/test_add_from_model_unknown_fields.py
@@ -101,6 +101,36 @@ async def test_add_from_model_accepts_flat_fields(monkeypatch):
 
 
 @pytest.mark.anyio
+async def test_add_from_model_accepts_plain_dict(monkeypatch):
+    captured_notes = {}
+
+    async def fake_anki_call(action, params):
+        nonlocal captured_notes
+        if action == "createDeck":
+            return None
+        if action == "modelFieldNames":
+            return ["Front", "Back"]
+        if action == "modelTemplates":
+            return {}
+        if action == "modelStyling":
+            return {"css": ""}
+        if action == "addNotes":
+            captured_notes = params
+            return [888]
+        raise AssertionError(f"Unexpected action: {action}")
+
+    monkeypatch.setattr("server.anki_call", fake_anki_call)
+
+    result = await add_from_model.fn(
+        deck="Deck", model="Basic", items=[{"Front": "Q", "Back": "A"}]
+    )
+
+    assert result.added == 1
+    assert captured_notes["notes"][0]["fields"] == {"Front": "Q", "Back": "A"}
+    assert captured_notes["notes"][0]["tags"] == []
+
+
+@pytest.mark.anyio
 async def test_add_notes_accepts_flat_fields(monkeypatch):
     captured_notes = {}
 


### PR DESCRIPTION
## Summary
- normalize raw add_from_model items so plain dicts are converted into NoteInput instances
- raise a friendly validation error when a dict item contains no recognizable note fields
- add a regression test ensuring add_from_model accepts dict-based note data

## Testing
- pytest *(fails: missing optional test dependencies such as pydantic/fastapi/PIL)*

------
https://chatgpt.com/codex/tasks/task_e_68cf138f5aa08330a6b5dbefbaa49107