### PR TITLE
Normalize note tags input and test string tags

### DIFF
--- a/tests/test_add_from_model_unknown_fields.py
+++ b/tests/test_add_from_model_unknown_fields.py
@@ -122,12 +122,14 @@ async def test_add_from_model_accepts_plain_dict(monkeypatch):
     monkeypatch.setattr("server.anki_call", fake_anki_call)
 
     result = await add_from_model.fn(
-        deck="Deck", model="Basic", items=[{"Front": "Q", "Back": "A"}]
+        deck="Deck",
+        model="Basic",
+        items=[{"Front": "Q", "Back": "A", "tags": "auto"}],
     )
 
     assert result.added == 1
     assert captured_notes["notes"][0]["fields"] == {"Front": "Q", "Back": "A"}
-    assert captured_notes["notes"][0]["tags"] == []
+    assert captured_notes["notes"][0]["tags"] == ["auto"]
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- normalize NoteInput.tags through a pre-validator that accepts strings or iterables and splits comma/whitespace-delimited tags
- ensure the add_from_model flow receives already-trimmed tag lists
- update the add_from_model plain dict test to cover string tag inputs

## Testing
- pytest tests/test_add_from_model_unknown_fields.py::test_add_from_model_accepts_plain_dict

------
https://chatgpt.com/codex/tasks/task_e_68cf1a01967c8330a157c834329c24df