### PR TITLE
Adjust search capability flag based on SEARCH_API_URL

### DIFF
--- a/server.py
+++ b/server.py
@@ -286,9 +286,15 @@ def _ensure_search_capability(manifest: dict) -> dict:
     existing_search = capabilities.get("search")
     if isinstance(existing_search, dict):
         updated_search = dict(existing_search)
-        updated_search["enabled"] = True
     else:
-        updated_search = {"enabled": True}
+        updated_search = {}
+
+    if SEARCH_API_URL:
+        updated_search["enabled"] = True
+        updated_search.pop("reason", None)
+    else:
+        updated_search["enabled"] = False
+        updated_search["reason"] = "SEARCH_API_URL is not configured"
     capabilities["search"] = updated_search
     manifest["capabilities"] = capabilities
     return manifest

--- a/tests/test_manifest_routes.py
+++ b/tests/test_manifest_routes.py
@@ -30,7 +30,22 @@ def test_manifest_endpoints_return_manifest_json(client, path):
         assert key in payload
 
     capabilities = payload.get("capabilities", {})
-    assert capabilities.get("search", {}).get("enabled") is True
+    search_info = capabilities.get("search", {})
+    assert search_info.get("enabled") is False
+    assert search_info.get("reason") == "SEARCH_API_URL is not configured"
+
+
+def test_manifest_search_capability_enabled_when_url(monkeypatch, client):
+    monkeypatch.setattr(server, "SEARCH_API_URL", "https://example.com/search")
+
+    response = client.get("/")
+
+    assert response.status_code == 200
+
+    payload = response.json()
+    search_info = payload.get("capabilities", {}).get("search", {})
+    assert search_info.get("enabled") is True
+    assert "reason" not in search_info
 
 
 def test_manifest_routes_without_fastapi(monkeypatch):
@@ -79,4 +94,5 @@ def test_manifest_routes_without_fastapi(monkeypatch):
     for key in ("mcp", "server", "tools"):
         assert key in payload
     capabilities = payload.get("capabilities", {})
-    assert capabilities.get("search", {}).get("enabled") is True
+    search_info = capabilities.get("search", {})
+    assert search_info.get("enabled") is False


### PR DESCRIPTION
## Summary
- disable the search capability in generated manifests when SEARCH_API_URL is not set and provide a reason
- ensure the manifest reuses the existing search entry when a URL is configured
- update manifest route tests to cover both disabled-by-default and enabled-with-URL scenarios

## Testing
- `pytest tests/test_manifest_routes.py`

------
https://chatgpt.com/codex/tasks/task_e_68cf1d776c1c8330a3ce047590524bc1