### PR TITLE
Support per-note deck and model overrides

### DIFF
--- a/tests/test_add_from_model_unknown_fields.py
+++ b/tests/test_add_from_model_unknown_fields.py
@@ -1,6 +1,7 @@
 import sys
 import types
 from pathlib import Path
+from typing import List
 
 import pytest
 
@@ -189,6 +190,119 @@ async def test_add_notes_accepts_flat_fields(monkeypatch):
     assert result.added == 1
     assert captured_notes["notes"][0]["fields"] == {"Front": "Q", "Back": "A"}
     assert captured_notes["notes"][0]["tags"] == []
+
+
+@pytest.mark.anyio
+async def test_add_from_model_respects_note_level_deck_and_model(monkeypatch):
+    captured_notes = {}
+    create_calls: List[str] = []
+    requested_models: List[str] = []
+
+    fields_by_model = {
+        "Basic": ["Front", "Back"],
+        "Cloze": ["Text", "Extra"],
+    }
+
+    async def fake_anki_call(action, params):
+        nonlocal captured_notes
+        if action == "createDeck":
+            create_calls.append(params["deck"])
+            return None
+        if action == "modelFieldNames":
+            model_name = params["modelName"]
+            requested_models.append(model_name)
+            return fields_by_model[model_name]
+        if action == "modelTemplates":
+            return {}
+        if action == "modelStyling":
+            return {"css": ""}
+        if action == "addNotes":
+            captured_notes = params
+            return [111, 222]
+        raise AssertionError(f"Unexpected action: {action}")
+
+    monkeypatch.setattr("server.anki_call", fake_anki_call)
+
+    default_note = NoteInput(Front="Q1", Back="A1")
+    override_note = NoteInput(
+        fields={"Text": "cloze", "Extra": "info"},
+        deckName="Special Deck",
+        modelName="Cloze",
+    )
+
+    result = await add_from_model.fn(
+        deck="Deck",
+        model="Basic",
+        items=[default_note, override_note],
+    )
+
+    assert result.added == 2
+    assert set(create_calls) == {"Deck", "Special Deck"}
+    assert set(requested_models) == {"Basic", "Cloze"}
+    assert captured_notes["notes"][0]["deckName"] == "Deck"
+    assert captured_notes["notes"][0]["modelName"] == "Basic"
+    assert captured_notes["notes"][1]["deckName"] == "Special Deck"
+    assert captured_notes["notes"][1]["modelName"] == "Cloze"
+    assert "deckName" not in captured_notes["notes"][1]["fields"]
+    assert "modelName" not in captured_notes["notes"][1]["fields"]
+
+
+@pytest.mark.anyio
+async def test_add_notes_respects_note_level_deck_and_model(monkeypatch):
+    captured_notes = {}
+    create_calls: List[str] = []
+    requested_models: List[str] = []
+
+    fields_by_model = {
+        "Basic": ["Front", "Back"],
+        "Cloze": ["Text", "Extra"],
+    }
+
+    async def fake_anki_call(action, params):
+        nonlocal captured_notes
+        if action == "createDeck":
+            create_calls.append(params["deck"])
+            return None
+        if action == "modelFieldNames":
+            model_name = params["modelName"]
+            requested_models.append(model_name)
+            return fields_by_model[model_name]
+        if action == "modelTemplates":
+            return {}
+        if action == "modelStyling":
+            return {"css": ""}
+        if action == "addNotes":
+            captured_notes = params
+            return [333, 444]
+        raise AssertionError(f"Unexpected action: {action}")
+
+    monkeypatch.setattr("server.anki_call", fake_anki_call)
+
+    args = AddNotesArgs(
+        deck="Deck",
+        model="Basic",
+        notes=[
+            {"Front": "Q1", "Back": "A1"},
+            {
+                "Text": "cloze",
+                "Extra": "info",
+                "deckName": "Special Deck",
+                "modelName": "Cloze",
+            },
+        ],
+    )
+
+    result = await add_notes.fn(args)
+
+    assert result.added == 2
+    assert set(create_calls) == {"Deck", "Special Deck"}
+    assert set(requested_models) == {"Basic", "Cloze"}
+    assert captured_notes["notes"][0]["deckName"] == "Deck"
+    assert captured_notes["notes"][0]["modelName"] == "Basic"
+    assert captured_notes["notes"][1]["deckName"] == "Special Deck"
+    assert captured_notes["notes"][1]["modelName"] == "Cloze"
+    assert "deckName" not in captured_notes["notes"][1]["fields"]
+    assert "modelName" not in captured_notes["notes"][1]["fields"]
 
 
 def test_note_input_requires_fields_or_flat_data():


### PR DESCRIPTION
## Summary
- allow note inputs to capture per-note deck/model metadata without leaking into fields
- respect note-level deck/model when constructing payloads and ensure required decks exist
- add regression tests covering custom deck/model propagation to Anki

## Testing
- pytest *(fails: ModuleNotFoundError for optional dependencies such as pydantic/requests/PIL/fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68cf206ab5e08330a93192c7ebedea4f