### PR TITLE
Avoid unnecessary template fetches in add_notes

### DIFF
--- a/server.py
+++ b/server.py
@@ -674,6 +674,12 @@ async def get_model_fields_templates(model: str) -> Tuple[List[str], Dict[str, D
     return fields, templates, styling.get("css", "")
 
 
+async def get_model_field_names(model: str) -> List[str]:
+    """Возвращает только названия полей модели."""
+
+    return await anki_call("modelFieldNames", {"modelName": model})
+
+
 def normalize_fields_for_model(
     user_fields: Dict[str, str], model_fields: List[str]
 ) -> Tuple[Dict[str, str], int, List[str]]:
@@ -1055,7 +1061,7 @@ async def add_notes(args: AddNotesArgs) -> AddNotesResult:
     async def _ensure_model_context(model_name: str) -> Tuple[List[str], Dict[str, str]]:
         cached_fields = model_fields_cache.get(model_name)
         if cached_fields is None:
-            fields, _, _ = await get_model_fields_templates(model_name)
+            fields = await get_model_field_names(model_name)
             model_fields_cache[model_name] = fields
             canonical_field_map_cache[model_name] = {
                 field.lower(): field for field in fields

--- a/tests/test_add_from_model_unknown_fields.py
+++ b/tests/test_add_from_model_unknown_fields.py
@@ -173,9 +173,9 @@ async def test_add_notes_accepts_flat_fields(monkeypatch):
         if action == "modelFieldNames":
             return ["Front", "Back"]
         if action == "modelTemplates":
-            return {}
+            raise AssertionError("modelTemplates should not be called for add_notes")
         if action == "modelStyling":
-            return {"css": ""}
+            raise AssertionError("modelStyling should not be called for add_notes")
         if action == "addNotes":
             captured_notes = params
             return [777]
@@ -268,9 +268,9 @@ async def test_add_notes_respects_note_level_deck_and_model(monkeypatch):
             requested_models.append(model_name)
             return fields_by_model[model_name]
         if action == "modelTemplates":
-            return {}
+            raise AssertionError("modelTemplates should not be called for add_notes")
         if action == "modelStyling":
-            return {"css": ""}
+            raise AssertionError("modelStyling should not be called for add_notes")
         if action == "addNotes":
             captured_notes = params
             return [333, 444]

--- a/tests/test_dedup_key.py
+++ b/tests/test_dedup_key.py
@@ -84,9 +84,9 @@ async def test_add_notes_includes_dedup_key(monkeypatch):
         if action == "modelFieldNames":
             return ["Front", "Back"]
         if action == "modelTemplates":
-            return {}
+            raise AssertionError("modelTemplates should not be called for add_notes")
         if action == "modelStyling":
-            return {"css": ""}
+            raise AssertionError("modelStyling should not be called for add_notes")
         if action == "addNotes":
             return [202, None]
         raise AssertionError(f"Unexpected action: {action}")
@@ -120,9 +120,9 @@ async def test_add_notes_lowercase_fields_empty_front(monkeypatch):
         if action == "modelFieldNames":
             return ["Front", "Back"]
         if action == "modelTemplates":
-            return {}
+            raise AssertionError("modelTemplates should not be called for add_notes")
         if action == "modelStyling":
-            return {"css": ""}
+            raise AssertionError("modelStyling should not be called for add_notes")
         if action == "addNotes":
             raise AssertionError("addNotes should not be called when fields invalid")
         raise AssertionError(f"Unexpected action: {action}")

--- a/tests/test_image_data_url.py
+++ b/tests/test_image_data_url.py
@@ -275,9 +275,9 @@ async def test_note_input_accepts_url_alias(monkeypatch):
         if action == "modelFieldNames":
             return ["Front", "Back"]
         if action == "modelTemplates":
-            return {"Card 1": {"Front": "{{Front}}", "Back": "{{Back}}"}}
+            raise AssertionError("modelTemplates should not be called for add_notes")
         if action == "modelStyling":
-            return {"css": ""}
+            raise AssertionError("modelStyling should not be called for add_notes")
         if action == "addNotes":
             captured["addNotes"] = params
             return [987]


### PR DESCRIPTION
## Summary
- add a dedicated helper to fetch model field names and use it inside `anki.add_notes`
- update the `anki.add_notes` test doubles to assert that `modelTemplates` and `modelStyling` are no longer queried

## Testing
- pytest *(fails: missing optional dependencies such as pydantic, requests, PIL, fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68cf2194606c8330b20ac5ffc56dbe1f