### PR TITLE
Optimize model field lookup

### DIFF
--- a/server.py
+++ b/server.py
@@ -903,9 +903,6 @@ async def add_from_model(
 
     await anki_call("createDeck", {"deck": deck})
 
-    model_fields, _, _ = await get_model_fields_templates(model)
-    field_aliases = {field.lower(): field for field in model_fields}
-
     normalized_items: List[NoteInput] = []
     for index, raw_item in enumerate(items):
         if isinstance(raw_item, NoteInput):
@@ -950,7 +947,7 @@ async def add_from_model(
     async def _ensure_model_context(model_name: str) -> Tuple[List[str], Dict[str, str]]:
         cached_fields = model_fields_cache.get(model_name)
         if cached_fields is None:
-            fields, _, _ = await get_model_fields_templates(model_name)
+            fields = await get_model_field_names(model_name)
             model_fields_cache[model_name] = fields
             field_aliases_cache[model_name] = {field.lower(): field for field in fields}
         return model_fields_cache[model_name], field_aliases_cache[model_name]


### PR DESCRIPTION
## Summary
- avoid fetching Anki model templates/styling when adding notes by caching only field names
- ensure model field lookups are cached on first use and shared across notes
- expand tests to verify only modelFieldNames is requested and add a FastMCP fallback that serves manifest routes in tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf235ac1dc8330b826e1e9cf45fa74