### PR TITLE
Handle exit codes for process monitoring

### DIFF
--- a/main.py
+++ b/main.py
@@ -278,16 +278,20 @@ if __name__ == "__main__":
     print("\nОставь окно открытым. Нажми Ctrl+C, чтобы остановить.")
 
     # 4) Основной цикл
+    exit_code = 0
     try:
         while True:
             time.sleep(1)
             if mcp.poll() is not None:
                 print("[error] MCP-сервер завершился. Останавливаемся.")
+                exit_code = 1
                 break
             if ng and ng.poll() is not None and not ngrok_api_alive():
                 print("[error] ngrok завершился. Останавливаемся.")
+                exit_code = 1
                 break
     except KeyboardInterrupt:
         pass
     finally:
         shutdown()
+    sys.exit(exit_code)


### PR DESCRIPTION
## Summary
- initialize exit_code tracking before the main monitoring loop
- flag abnormal shutdowns from the MCP or ngrok processes to return exit code 1
- exit the script with the recorded status while preserving KeyboardInterrupt handling

## Testing
- pytest *(fails: missing dependencies such as pydantic, requests, PIL, fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68cf294095408330b292d3086b5c0fd5