### PR TITLE
Update default Anki model name

### DIFF
--- a/env.example
+++ b/env.example
@@ -2,9 +2,9 @@
 NGROK_AUTHTOKEN=
 
 # Необязательные дефолты для инструментов Anki.
-# Пустое значение приведёт к использованию стандартных "Default" / "Basic".
+# Пустое значение приведёт к использованию стандартных "Default" / "Поля для ChatGPT".
 ANKI_DEFAULT_DECK=Default
-ANKI_DEFAULT_MODEL=Basic
+ANKI_DEFAULT_MODEL=Поля для ChatGPT
 
 # Настройки внешнего поиска
 SEARCH_API_URL=

--- a/server.py
+++ b/server.py
@@ -209,7 +209,7 @@ def _env_optional(name: str) -> Optional[str]:
 
 
 DEFAULT_DECK = _env_default("ANKI_DEFAULT_DECK", "Default")
-DEFAULT_MODEL = _env_default("ANKI_DEFAULT_MODEL", "Basic")
+DEFAULT_MODEL = _env_default("ANKI_DEFAULT_MODEL", "Поля для ChatGPT")
 SEARCH_API_URL = _env_optional("SEARCH_API_URL")
 SEARCH_API_KEY = _env_optional("SEARCH_API_KEY")
 

--- a/tests/test_server_environment.py
+++ b/tests/test_server_environment.py
@@ -33,7 +33,7 @@ def test_env_defaults_fallback_when_blank():
         module = importlib.reload(server)
 
         assert module.DEFAULT_DECK == "Default"
-        assert module.DEFAULT_MODEL == "Basic"
+        assert module.DEFAULT_MODEL == "Поля для ChatGPT"
     finally:
         _restore_env(original_deck, original_model)
         importlib.reload(server)


### PR DESCRIPTION
## Summary
- change the default Anki model name to "Поля для ChatGPT"
- update the environment example file to match the new default
- adjust environment-related tests to expect the new model name

## Testing
- `PYTHONPATH=. pytest tests/test_server_environment.py`


------
https://chatgpt.com/codex/tasks/task_e_68cf2a948d20833083b1bccfa1cdce65