### PR TITLE
Update AwesomeTTS field references

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@
 ```html
 <div class="sentence">{{Sentence}}</div>
 <div class="hint">{{Hint}}</div>
-{{tts de_DE voices=AwesomeTTS:SentenceDE}}
+{{tts de_DE voices=AwesomeTTS:Sentence}}
 ```
 
 ### Шаблон «Back»
@@ -110,7 +110,7 @@
 }
 ```
 
-TTS-вызов `{{tts de_DE voices=AwesomeTTS:SentenceDE}}` размещён на лицевой стороне и использует плагин AwesomeTTS с голосовым профилем `SentenceDE`. Убедитесь, что соответствующий профиль активирован в Anki, иначе воспроизведение произойдёт с настройками по умолчанию.
+TTS-вызов `{{tts de_DE voices=AwesomeTTS:Sentence}}` размещён на лицевой стороне и использует плагин AwesomeTTS с голосовым профилем `Sentence`, привязанным к полю `Sentence`. Убедитесь, что соответствующий профиль активирован в Anki, иначе воспроизведение произойдёт с настройками по умолчанию.
 
 ## Локальный smoke-тест
 Запустите `python test_client.py`, чтобы проверить базовое взаимодействие с MCP-сервером без туннеля.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -112,7 +112,7 @@
   "fields": ["Sentence", "Translation", "Hint", "Notes"],
   "templates": {
     "Card 1": {
-      "Front": "<div class=\"sentence\">{{Sentence}}</div>\n<div class=\"hint\">{{Hint}}</div>\n{{tts de_DE voices=AwesomeTTS:SentenceDE}}",
+      "Front": "<div class=\"sentence\">{{Sentence}}</div>\n<div class=\"hint\">{{Hint}}</div>\n{{tts de_DE voices=AwesomeTTS:Sentence}}",
       "Back": "{{FrontSide}}\n<hr id=\"answer\">\n<div class=\"translation\">{{Translation}}</div>\n<div class=\"notes\">{{Notes}}</div>"
     }
   },
@@ -120,7 +120,7 @@
 }
 ```
 
-> **Важно.** Клиент должен передавать значения полей строго в порядке `Sentence`, `Translation`, `Hint`, `Notes`. Шаблон фронта включает вызов `{{tts de_DE voices=AwesomeTTS:SentenceDE}}`, поэтому в Anki должен быть настроен профиль AwesomeTTS `SentenceDE`.
+> **Важно.** Клиент должен передавать значения полей строго в порядке `Sentence`, `Translation`, `Hint`, `Notes`. Шаблон фронта включает вызов `{{tts de_DE voices=AwesomeTTS:Sentence}}`, поэтому в Anki должен быть настроен профиль AwesomeTTS `Sentence`, который озвучивает поле `Sentence`.
 
 ### `anki.add_from_model`
 - **Назначение:** добавить заметки в указанную колоду с учётом текущих полей и шаблонов модели. Инструмент сам загружает структуру модели, нормализует `fields` и обрабатывает вложенные изображения.
@@ -181,7 +181,7 @@
 }
 ```
 
-> **Напоминание.** Даже если поля передаются объектом `fields`, сервер сопоставляет их с порядком `Sentence → Translation → Hint → Notes`, чтобы шаблон с TTS `{{tts de_DE voices=AwesomeTTS:SentenceDE}}` оставался валидным.
+> **Напоминание.** Даже если поля передаются объектом `fields`, сервер сопоставляет их с порядком `Sentence → Translation → Hint → Notes`, чтобы шаблон с TTS `{{tts de_DE voices=AwesomeTTS:Sentence}}` оставался валидным и продолжал озвучивать поле `Sentence` через профиль AwesomeTTS `Sentence`.
 
 ### `anki.note_info`
 - **Назначение:** получить подробные сведения о заметках по их идентификаторам.


### PR DESCRIPTION
## Summary
- replace the placeholder AwesomeTTS voice reference with the actual Sentence field
- clarify that the AwesomeTTS Sentence profile is linked to the Sentence field in the model

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68cf2d77103483308d9cc044258c0e5e