### PR TITLE
Update documentation for ChatGPT note model

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
    - Оставьте окно запущенного скрипта открытым (терминал с `python main.py`); завершение `Ctrl+C` корректно остановит MCP и ngrok, а при закрытом терминале коннектор станет недоступен.
 
 ## Что умеет сервер
-- `anki.model_info` — возвращает актуальные поля, шаблоны карточек и CSS выбранной модели Anki, чтобы ChatGPT мог заранее сформировать корректные поля. Параметр `model` можно не передавать — по умолчанию используется `ANKI_DEFAULT_MODEL` (`"Sentence (DE)"`, если переменная не задана или пуста).
+- `anki.model_info` — возвращает актуальные поля, шаблоны карточек и CSS выбранной модели Anki, чтобы ChatGPT мог заранее сформировать корректные поля. Параметр `model` можно не передавать — по умолчанию используется `ANKI_DEFAULT_MODEL` (`"Поля для ChatGPT"`, если переменная не задана или пуста).
 - `anki.add_from_model` — нормализует поля под модель, преобразует встроенные `data:`-URL в медиафайлы, загружает изображения по URL/base64 с ресайзом и отмечает результаты через `dedup_key`, помогая ChatGPT безопасно обновлять карточки без дублей.
 - `anki.add_notes` — низкоуровневый аналог без авто-подстановки полей модели для случаев, когда структуру карточки контролирует пользователь.
 - `anki.note_info` — возвращает подробные данные о заметках (поля, теги, карточки) по их идентификаторам, что помогает уточнять существующие записи перед обновлениями.
@@ -55,62 +55,61 @@
 
 ## Модель Anki по умолчанию
 
-По умолчанию сервер работает с пользовательской моделью `Sentence (DE)`. Чтобы запросы `anki.model_info` и `anki.add_from_model` корректно формировали заметки, важно сохранять порядок полей и шаблоны ровно в том виде, в котором они описаны ниже.
+По умолчанию сервер работает с пользовательской моделью `Поля для ChatGPT`. Чтобы запросы `anki.model_info` и `anki.add_from_model` корректно формировали заметки, важно сохранять порядок полей и шаблоны ровно в том виде, в котором они описаны ниже.
 
 ### Поля (порядок обязателен)
-1. `Sentence` — немецкое предложение.
-2. `Translation` — перевод.
-3. `Hint` — краткая подсказка (грамматика, комментарий).
-4. `Notes` — дополнительные пояснения или источник.
+1. `Prompt` — исходный запрос или задача.
+2. `Response` — ответ ChatGPT.
+3. `Context` — дополнительная информация, которую следует помнить при повторении.
+4. `Sources` — ссылки на материалы, выдержки из документов и другие источники.
 
 ### Шаблон «Front»
 ```html
-<div class="sentence">{{Sentence}}</div>
-<div class="hint">{{Hint}}</div>
-{{tts de_DE voices=AwesomeTTS:SentenceDE}}
+<div class="prompt">{{Prompt}}</div>
+<div class="context">{{Context}}</div>
 ```
 
 ### Шаблон «Back»
 ```html
 {{FrontSide}}
 <hr id="answer">
-<div class="translation">{{Translation}}</div>
-<div class="notes">{{Notes}}</div>
+<div class="response">{{Response}}</div>
+<div class="sources">{{Sources}}</div>
 ```
 
 ### CSS модели
 ```css
 .card {
-  font-family: "Fira Sans", sans-serif;
-  font-size: 26px;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  font-size: 22px;
   text-align: left;
-  line-height: 1.45;
+  line-height: 1.5;
 }
 
-.sentence {
+.prompt {
   font-weight: 600;
+  font-size: 24px;
   margin-bottom: 12px;
 }
 
-.hint {
+.context {
   color: #4a5568;
   font-style: italic;
   margin-bottom: 16px;
 }
 
-.translation {
-  color: #2d3748;
-  font-size: 24px;
+.response {
+  color: #1a202c;
+  font-size: 22px;
   margin-bottom: 12px;
 }
 
-.notes {
+.sources {
   color: #2d3748;
-  font-size: 20px;
+  font-size: 18px;
+  white-space: pre-wrap;
 }
 ```
-
-TTS-вызов `{{tts de_DE voices=AwesomeTTS:SentenceDE}}` размещён на лицевой стороне и использует плагин AwesomeTTS с голосовым профилем `SentenceDE`. Убедитесь, что соответствующий профиль активирован в Anki, иначе воспроизведение произойдёт с настройками по умолчанию.
 
 ## Локальный smoke-тест
 Запустите `python test_client.py`, чтобы проверить базовое взаимодействие с MCP-сервером без туннеля.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -6,11 +6,11 @@
 ## Переменные окружения
 
 - `ANKI_DEFAULT_DECK` — имя колоды, которое будет использоваться по умолчанию, если клиент не передал параметр `deck`.
-- `ANKI_DEFAULT_MODEL` — имя модели, используемой по умолчанию при отсутствии параметра `model`. По умолчанию это пользовательская модель `Sentence (DE)` c полями `Sentence`, `Translation`, `Hint`, `Notes` (в этом порядке).
+- `ANKI_DEFAULT_MODEL` — имя модели, используемой по умолчанию при отсутствии параметра `model`. По умолчанию это пользовательская модель `Поля для ChatGPT` c полями `Prompt`, `Response`, `Context`, `Sources` (в этом порядке).
 - `SEARCH_API_URL` — базовый URL внешнего поиска (HTTP endpoint, webhook n8n и т.п.), который будет вызываться действием `search`.
 - `SEARCH_API_KEY` — необязательный ключ/токен для авторизации во внешнем поиске. Если не задан, заголовок `Authorization` не добавляется.
 
-Переменные для Anki необязательные: пустое значение приводит к использованию стандартных `"Default"` и `"Sentence (DE)"` соответственно.
+Переменные для Anki необязательные: пустое значение приводит к использованию стандартных `"Default"` и `"Поля для ChatGPT"` соответственно.
 Переменные поиска также можно оставить пустыми — тогда действие `search` будет недоступно и сервер сообщит об ошибке при попытке вызвать его без настроек.
 
 ## Общие структуры данных
@@ -48,7 +48,7 @@
 - **Используется в:** `anki.add_notes`.
 - **Поля:**
   - `deck: str` — имя колоды. Если параметр не передан, используется значение из `ANKI_DEFAULT_DECK` (по умолчанию `"Default"`).
-  - `model: str` — имя модели. При отсутствии значения используется `ANKI_DEFAULT_MODEL` (по умолчанию `"Sentence (DE)"`).
+  - `model: str` — имя модели. При отсутствии значения используется `ANKI_DEFAULT_MODEL` (по умолчанию `"Поля для ChatGPT"`).
   - `notes: List[NoteInput]` — список заметок (обязательный, минимум один элемент).
 
 ### `AddNotesResult`
@@ -94,39 +94,39 @@
 ### `anki.model_info`
 - **Назначение:** получить актуальные поля, шаблоны (Front/Back) и CSS выбранной модели Anki.
 - **Параметры:**
-  - `model: str` — имя модели. Если параметр опущен, используется `ANKI_DEFAULT_MODEL` (`"Sentence (DE)"`, если переменная не задана или пуста).
+  - `model: str` — имя модели. Если параметр опущен, используется `ANKI_DEFAULT_MODEL` (`"Поля для ChatGPT"`, если переменная не задана или пуста).
 - **Ответ:** объект `ModelInfo` (см. выше).
 - **Пример запроса:**
 ```json
 {
   "name": "anki.model_info",
   "arguments": {
-    "model": "Sentence (DE)"
+    "model": "Поля для ChatGPT"
   }
 }
 ```
 - **Пример ответа:**
 ```json
 {
-  "model": "Sentence (DE)",
-  "fields": ["Sentence", "Translation", "Hint", "Notes"],
+  "model": "Поля для ChatGPT",
+  "fields": ["Prompt", "Response", "Context", "Sources"],
   "templates": {
     "Card 1": {
-      "Front": "<div class=\"sentence\">{{Sentence}}</div>\n<div class=\"hint\">{{Hint}}</div>\n{{tts de_DE voices=AwesomeTTS:SentenceDE}}",
-      "Back": "{{FrontSide}}\n<hr id=\"answer\">\n<div class=\"translation\">{{Translation}}</div>\n<div class=\"notes\">{{Notes}}</div>"
+      "Front": "<div class=\"prompt\">{{Prompt}}</div>\n<div class=\"context\">{{Context}}</div>",
+      "Back": "{{FrontSide}}\n<hr id=\"answer\">\n<div class=\"response\">{{Response}}</div>\n<div class=\"sources\">{{Sources}}</div>"
     }
   },
-  "styling": ".card {\n  font-family: \"Fira Sans\", sans-serif;\n  font-size: 26px;\n  text-align: left;\n  line-height: 1.45;\n}\n.sentence {\n  font-weight: 600;\n  margin-bottom: 12px;\n}\n.hint {\n  color: #4a5568;\n  font-style: italic;\n  margin-bottom: 16px;\n}\n.translation {\n  color: #2d3748;\n  font-size: 24px;\n  margin-bottom: 12px;\n}\n.notes {\n  color: #2d3748;\n  font-size: 20px;\n}"
+  "styling": ".card {\n  font-family: \"Inter\", \"Segoe UI\", sans-serif;\n  font-size: 22px;\n  text-align: left;\n  line-height: 1.5;\n}\n.prompt {\n  font-weight: 600;\n  font-size: 24px;\n  margin-bottom: 12px;\n}\n.context {\n  color: #4a5568;\n  font-style: italic;\n  margin-bottom: 16px;\n}\n.response {\n  color: #1a202c;\n  font-size: 22px;\n  margin-bottom: 12px;\n}\n.sources {\n  color: #2d3748;\n  font-size: 18px;\n  white-space: pre-wrap;\n}"
 }
 ```
 
-> **Важно.** Клиент должен передавать значения полей строго в порядке `Sentence`, `Translation`, `Hint`, `Notes`. Шаблон фронта включает вызов `{{tts de_DE voices=AwesomeTTS:SentenceDE}}`, поэтому в Anki должен быть настроен профиль AwesomeTTS `SentenceDE`.
+> **Важно.** Клиент должен передавать значения полей строго в порядке `Prompt`, `Response`, `Context`, `Sources`, иначе часть данных окажется пустой.
 
 ### `anki.add_from_model`
 - **Назначение:** добавить заметки в указанную колоду с учётом текущих полей и шаблонов модели. Инструмент сам загружает структуру модели, нормализует `fields` и обрабатывает вложенные изображения.
 - **Параметры:**
   - `deck: str` — целевая колода. Если параметр опущен, используется `ANKI_DEFAULT_DECK` (`"Default"`, если переменная не задана или пуста).
-  - `model: str` — модель карточки. По умолчанию берётся `ANKI_DEFAULT_MODEL` (`"Sentence (DE)"`, если переменная не задана или пуста).
+  - `model: str` — модель карточки. По умолчанию берётся `ANKI_DEFAULT_MODEL` (`"Поля для ChatGPT"`, если переменная не задана или пуста).
   - `items: List[NoteInput | dict]` — список заметок (обязателен). Для каждого элемента можно передавать:
     - полноценный объект `NoteInput` с ключами `fields`/`tags`/`images`/`dedup_key`;
     - или плоский словарь, где верхнеуровневые ключи соответствуют полям модели, а служебные атрибуты (`tags`, `images`, `dedup_key`) указываются рядом.
@@ -142,22 +142,22 @@
   "name": "anki.add_from_model",
   "arguments": {
     "deck": "Default",
-    "model": "Sentence (DE)",
+    "model": "Поля для ChatGPT",
     "items": [
       {
-        "Sentence": "Die Hauptstadt von Frankreich ist?",
-        "Translation": "Столица Франции — Париж.",
-        "Hint": "Wortstellung во вопросах с ist",
-        "Notes": "Источник: https://de.wikipedia.org/wiki/Paris",
+        "Prompt": "Расскажи коротко про столицу Франции",
+        "Response": "Столица Франции — Париж.",
+        "Context": "Основные факты",
+        "Sources": "https://ru.wikipedia.org/wiki/Париж",
         "tags": ["geo", "de"],
         "dedup_key": "geo-paris"
       },
       {
         "fields": {
-          "Sentence": "Wie heißt die Hauptstadt von Deutschland?",
-          "Translation": "Столица Германии — Берлин.",
-          "Hint": "Fragewort + глагол на втором месте",
-          "Notes": "Источник: https://de.wikipedia.org/wiki/Berlin"
+          "Prompt": "Что нужно знать о столице Германии?",
+          "Response": "Столица Германии — Берлин.",
+          "Context": "Краткая справка",
+          "Sources": "https://ru.wikipedia.org/wiki/Берлин"
         },
         "tags": ["geo", "de"]
       }
@@ -181,7 +181,7 @@
 }
 ```
 
-> **Напоминание.** Даже если поля передаются объектом `fields`, сервер сопоставляет их с порядком `Sentence → Translation → Hint → Notes`, чтобы шаблон с TTS `{{tts de_DE voices=AwesomeTTS:SentenceDE}}` оставался валидным.
+> **Напоминание.** Даже если поля передаются объектом `fields`, сервер сопоставляет их с порядком `Prompt → Response → Context → Sources`, чтобы карточка отображалась корректно.
 
 ### `anki.note_info`
 - **Назначение:** получить подробные сведения о заметках по их идентификаторам.
@@ -210,14 +210,14 @@
   "notes": [
     {
       "noteId": 1700000000000,
-      "modelName": "Sentence (DE)",
+      "modelName": "Поля для ChatGPT",
       "deckName": "Default",
       "tags": ["geo"],
       "fields": {
-        "Sentence": "Die Hauptstadt von Frankreich ist?",
-        "Translation": "Столица Франции — Париж.",
-        "Hint": "Wortstellung во вопросах с ist",
-        "Notes": "Источник: https://de.wikipedia.org/wiki/Paris"
+        "Prompt": "Расскажи коротко про столицу Франции",
+        "Response": "Столица Франции — Париж.",
+        "Context": "Основные факты",
+        "Sources": "https://ru.wikipedia.org/wiki/Париж"
       },
       "cards": [1700000000100]
     },
@@ -230,7 +230,7 @@
 - **Назначение:** низкоуровневое добавление заметок без автоматической подстройки под структуру модели. Используется для случаев, когда клиент уже знает точное соответствие полей.
 - **Параметры:**
   - `deck: str` — целевая колода. При отсутствии параметра используется `ANKI_DEFAULT_DECK` (`"Default"`).
-  - `model: str` — модель карточки. Если аргумент опущен, применяется `ANKI_DEFAULT_MODEL` (`"Sentence (DE)"`).
+  - `model: str` — модель карточки. Если аргумент опущен, применяется `ANKI_DEFAULT_MODEL` (`"Поля для ChatGPT"`).
   - `notes: List[NoteInput]` — список заметок (обязателен, минимум один).
 - **Ответ:** объект `AddNotesResult`.
 - **Особенности:**
@@ -244,14 +244,14 @@
   "name": "anki.add_notes",
   "arguments": {
     "deck": "Default",
-    "model": "Sentence (DE)",
+    "model": "Поля для ChatGPT",
     "notes": [
       {
         "fields": {
-          "Sentence": "Das ist nur ein Test.",
-          "Translation": "Это просто тест.",
-          "Hint": "Нейтральное предложение",
-          "Notes": "Создано вручную через add_notes"
+          "Prompt": "Это тестовая карточка",
+          "Response": "Ответ добавлен через add_notes.",
+          "Context": "Проверка низкоуровневого метода",
+          "Sources": ""
         },
         "tags": [],
         "images": []


### PR DESCRIPTION
## Summary
- обновил README с описанием модели «Поля для ChatGPT», включая новые поля, шаблоны и CSS
- синхронизировал docs/tools.md с актуальными значениями переменной ANKI_DEFAULT_MODEL и примерами для «Поля для ChatGPT»

## Testing
- pytest *(fails: отсутствуют зависимости fastapi/pydantic/requests/Pillow в окружении)*

------
https://chatgpt.com/codex/tasks/task_e_68cf2d7081c483309ba536f88bdd5e5f