### PR TITLE
Refresh Anki defaults from config at runtime

### DIFF
--- a/anki_mcp/schemas/notes.py
+++ b/anki_mcp/schemas/notes.py
@@ -16,7 +16,7 @@ from ..compat import (
     root_validator,
     validator,
 )
-from ..config import DEFAULT_DECK, DEFAULT_MODEL
+from .. import config
 from .images import ImageSpec
 
 
@@ -138,9 +138,19 @@ class NoteInput(BaseModel):
             return _normalize_note_input_tags(value)
 
 
+def _default_deck() -> str:
+    return config.DEFAULT_DECK
+
+
+def _default_model() -> str:
+    return config.DEFAULT_MODEL
+
+
 class AddNotesArgs(BaseModel):
-    deck: constr(strip_whitespace=True, min_length=1) = Field(default=DEFAULT_DECK)
-    model: constr(strip_whitespace=True, min_length=1) = Field(default=DEFAULT_MODEL)
+    deck: constr(strip_whitespace=True, min_length=1) = Field(default_factory=_default_deck)
+    model: constr(strip_whitespace=True, min_length=1) = Field(
+        default_factory=_default_model
+    )
     notes: List[NoteInput] = Field(min_length=1)
 
 

--- a/anki_mcp/services/anki.py
+++ b/anki_mcp/services/anki.py
@@ -13,14 +13,20 @@ import httpx
 from PIL import Image
 
 from ..compat import model_validate
-from ..config import ANKI_URL
+from .. import config
 from ..schemas import NoteInfo
+
+
+def __getattr__(name: str):  # pragma: no cover - simple module proxy
+    if name == "ANKI_URL":
+        return config.ANKI_URL
+    raise AttributeError(f"module 'anki_mcp.services.anki' has no attribute {name!r}")
 
 
 async def anki_call(action: str, params: dict):
     payload = {"action": action, "version": 6, "params": params}
     async with httpx.AsyncClient(timeout=25) as client:
-        response = await client.post(ANKI_URL, json=payload)
+        response = await client.post(config.ANKI_URL, json=payload)
         response.raise_for_status()
         data = response.json()
         if data.get("error"):

--- a/anki_mcp/tools/anki.py
+++ b/anki_mcp/tools/anki.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 from .. import app
 from ..compat import model_validate
-from ..config import DEFAULT_DECK, DEFAULT_MODEL
+from .. import config
 from ..schemas import (
     AddNotesArgs,
     AddNotesResult,
@@ -65,19 +65,23 @@ async def note_info(args: NoteInfoArgs) -> NoteInfoResponse:
 
 
 @app.tool(name="anki.model_info")
-async def model_info(model: str = DEFAULT_MODEL) -> ModelInfo:
-    fields, templates, css = await anki_services.get_model_fields_templates(model)
-    return ModelInfo(model=model, fields=fields, templates=templates, styling=css)
+async def model_info(model: Optional[str] = None) -> ModelInfo:
+    target_model = model or config.DEFAULT_MODEL
+    fields, templates, css = await anki_services.get_model_fields_templates(target_model)
+    return ModelInfo(model=target_model, fields=fields, templates=templates, styling=css)
 
 
 @app.tool(name="anki.add_from_model")
 async def add_from_model(
-    deck: str = DEFAULT_DECK,
-    model: str = DEFAULT_MODEL,
+    deck: Optional[str] = None,
+    model: Optional[str] = None,
     items: Optional[List[Union[NoteInput, Dict[str, str]]]] = None,
 ) -> AddNotesResult:
     if items is None:
         raise ValueError("items must be provided")
+
+    deck = deck or config.DEFAULT_DECK
+    model = model or config.DEFAULT_MODEL
 
     await anki_services.anki_call("createDeck", {"deck": deck})
 

--- a/tests/test_server_environment.py
+++ b/tests/test_server_environment.py
@@ -1,7 +1,13 @@
 import importlib
 import os
+import sys
+from pathlib import Path
 
 import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 
 import server
 
@@ -55,6 +61,83 @@ async def test_manifest_environment_contains_defaults():
         manifest = await module._build_manifest()
         assert manifest["environment"]["defaultDeck"] == "DeckFromEnv"
         assert manifest["environment"]["defaultModel"] == "ModelFromEnv"
+    finally:
+        _restore_env(original_deck, original_model)
+        importlib.reload(server)
+
+
+@pytest.mark.anyio
+async def test_add_tools_follow_reloaded_defaults(monkeypatch):
+    original_deck = os.environ.get("ANKI_DEFAULT_DECK")
+    original_model = os.environ.get("ANKI_DEFAULT_MODEL")
+
+    try:
+        os.environ["ANKI_DEFAULT_DECK"] = "ReloadDeck"
+        os.environ["ANKI_DEFAULT_MODEL"] = "ReloadModel"
+        module = importlib.reload(server)
+
+        async def fake_get_model_field_names(model_name):
+            assert model_name == "ReloadModel"
+            return ["Front", "Back"]
+
+        monkeypatch.setattr(
+            "anki_mcp.services.anki.get_model_field_names",
+            fake_get_model_field_names,
+        )
+
+        captured_from_model = []
+
+        async def fake_anki_call_model(action, params):
+            captured_from_model.append((action, params))
+            if action == "createDeck":
+                return None
+            if action == "addNotes":
+                return [111]
+            raise AssertionError(f"Unexpected action for add_from_model: {action}")
+
+        monkeypatch.setattr(
+            "anki_mcp.services.anki.anki_call", fake_anki_call_model
+        )
+
+        note = module.NoteInput(Front="Q", Back="A")
+        result_from_model = await module.add_from_model.fn(items=[note])
+        assert result_from_model.added == 1
+
+        add_from_model_payload = next(
+            params for action, params in captured_from_model if action == "addNotes"
+        )
+        note_payload = add_from_model_payload["notes"][0]
+        assert note_payload["deckName"] == "ReloadDeck"
+        assert note_payload["modelName"] == "ReloadModel"
+
+        captured_add_notes = []
+
+        async def fake_anki_call_notes(action, params):
+            captured_add_notes.append((action, params))
+            if action == "createDeck":
+                return None
+            if action == "addNotes":
+                return [222]
+            raise AssertionError(f"Unexpected action for add_notes: {action}")
+
+        monkeypatch.setattr(
+            "anki_mcp.services.anki.anki_call", fake_anki_call_notes
+        )
+
+        second_note = module.NoteInput(Front="Q2", Back="A2")
+        args = module.AddNotesArgs(notes=[second_note])
+        assert args.deck == "ReloadDeck"
+        assert args.model == "ReloadModel"
+
+        result_add_notes = await module.add_notes.fn(args)
+        assert result_add_notes.added == 1
+
+        add_notes_payload = next(
+            params for action, params in captured_add_notes if action == "addNotes"
+        )
+        second_note_payload = add_notes_payload["notes"][0]
+        assert second_note_payload["deckName"] == "ReloadDeck"
+        assert second_note_payload["modelName"] == "ReloadModel"
     finally:
         _restore_env(original_deck, original_model)
         importlib.reload(server)


### PR DESCRIPTION
## Summary
- load tool defaults from `anki_mcp.config` at call time so reloaded values are used
- read the Anki Connect URL directly from `anki_mcp.config` when invoking the service client
- update note schemas and tests to validate the refreshed defaults after reloading the server

## Testing
- pytest tests/test_server_environment.py tests/test_add_from_model_unknown_fields.py tests/test_dedup_key.py


------
https://chatgpt.com/codex/tasks/task_e_68cfd0ad2a508330878443ad2f9c1519