### PR TITLE
Delegate config values via module __getattr__

### DIFF
--- a/anki_mcp/__init__.py
+++ b/anki_mcp/__init__.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from fastmcp import FastMCP
 
 
@@ -14,16 +16,18 @@ if not hasattr(app, "action"):
 
 from . import actions  # noqa: E402 - регистрация действий
 from . import tools  # noqa: E402 - регистрация инструментов
-from .config import (
-    ANKI_URL,
-    DEFAULT_DECK,
-    DEFAULT_MODEL,
-    ENVIRONMENT_INFO,
-    SEARCH_API_KEY,
-    SEARCH_API_URL,
-    _env_default,
-    _env_optional,
-)
+from . import config as _config
+from .config import _env_default, _env_optional
+
+if TYPE_CHECKING:  # pragma: no cover - подсказки типов при статическом анализе
+    from .config import (
+        ANKI_URL,
+        DEFAULT_DECK,
+        DEFAULT_MODEL,
+        ENVIRONMENT_INFO,
+        SEARCH_API_KEY,
+        SEARCH_API_URL,
+    )
 from .manifest import (
     _build_manifest,
     _manifest_response,
@@ -85,3 +89,23 @@ __all__ = [
     "read_root",
     "read_well_known_manifest",
 ]
+
+
+_CONFIG_EXPORTS = {
+    "DEFAULT_DECK",
+    "DEFAULT_MODEL",
+    "ENVIRONMENT_INFO",
+    "SEARCH_API_URL",
+    "SEARCH_API_KEY",
+    "ANKI_URL",
+}
+
+
+def __getattr__(name: str):
+    if name in _CONFIG_EXPORTS:
+        return getattr(_config, name)
+    raise AttributeError(f"module 'anki_mcp' has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(set(globals()) | _CONFIG_EXPORTS)

--- a/tests/test_server_environment.py
+++ b/tests/test_server_environment.py
@@ -45,6 +45,24 @@ def test_env_defaults_fallback_when_blank():
         importlib.reload(server)
 
 
+def test_package_exports_follow_reload():
+    import anki_mcp
+
+    original_deck = os.environ.get("ANKI_DEFAULT_DECK")
+    original_model = os.environ.get("ANKI_DEFAULT_MODEL")
+
+    try:
+        os.environ["ANKI_DEFAULT_DECK"] = "PackageDeck"
+        os.environ["ANKI_DEFAULT_MODEL"] = "PackageModel"
+        anki_mcp.config.reload_from_env()
+
+        assert anki_mcp.DEFAULT_DECK == "PackageDeck"
+        assert anki_mcp.DEFAULT_MODEL == "PackageModel"
+    finally:
+        _restore_env(original_deck, original_model)
+        anki_mcp.config.reload_from_env()
+
+
 @pytest.mark.anyio
 async def test_manifest_environment_contains_defaults():
     original_deck = os.environ.get("ANKI_DEFAULT_DECK")


### PR DESCRIPTION
## Summary
- stop binding the exported configuration constants in anki_mcp.__init__ and proxy them to anki_mcp.config via __getattr__
- keep static imports available for tooling via TYPE_CHECKING hints while exposing the runtime config values dynamically
- extend the environment tests to ensure reloading the config updates the package-level exports

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cfde47b59883308db4e3a26222a386