### PR TITLE
Refactor server config exports

### DIFF
--- a/server.py
+++ b/server.py
@@ -54,12 +54,24 @@ from anki_mcp.tools.misc import greet
 
 _config.reload_from_env()
 
-DEFAULT_DECK = _config.DEFAULT_DECK
-DEFAULT_MODEL = _config.DEFAULT_MODEL
-SEARCH_API_URL = _config.SEARCH_API_URL
-SEARCH_API_KEY = _config.SEARCH_API_KEY
-ENVIRONMENT_INFO = _config.ENVIRONMENT_INFO
-ANKI_URL = _config.ANKI_URL
+_CONFIG_EXPORTS = {
+    "DEFAULT_DECK",
+    "DEFAULT_MODEL",
+    "SEARCH_API_URL",
+    "SEARCH_API_KEY",
+    "ENVIRONMENT_INFO",
+    "ANKI_URL",
+}
+
+
+def __getattr__(name: str):
+    if name in _CONFIG_EXPORTS:
+        return getattr(_config, name)
+    raise AttributeError(f"module 'server' has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(set(globals()) | _CONFIG_EXPORTS)
 
 # Обеспечиваем доступ к httpx для тестовых заглушек.
 httpx = search_services.httpx

--- a/tests/test_server_environment.py
+++ b/tests/test_server_environment.py
@@ -63,6 +63,27 @@ def test_package_exports_follow_reload():
         anki_mcp.config.reload_from_env()
 
 
+def test_server_exports_follow_reload():
+    import anki_mcp
+
+    original_deck = os.environ.get("ANKI_DEFAULT_DECK")
+    original_model = os.environ.get("ANKI_DEFAULT_MODEL")
+
+    try:
+        os.environ["ANKI_DEFAULT_DECK"] = "ServerDeck"
+        os.environ["ANKI_DEFAULT_MODEL"] = "ServerModel"
+        anki_mcp.config.reload_from_env()
+
+        assert server.DEFAULT_DECK == "ServerDeck"
+        assert server.ENVIRONMENT_INFO == {
+            "defaultDeck": "ServerDeck",
+            "defaultModel": "ServerModel",
+        }
+    finally:
+        _restore_env(original_deck, original_model)
+        anki_mcp.config.reload_from_env()
+
+
 @pytest.mark.anyio
 async def test_manifest_environment_contains_defaults():
     original_deck = os.environ.get("ANKI_DEFAULT_DECK")


### PR DESCRIPTION
## Summary
- expose server configuration attributes dynamically via __getattr__ to ensure fresh values from anki_mcp.config
- extend environment reload test coverage to validate server module re-exports after reloading configuration

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cfe336e7b883308355d8a3ed41db10