### PR TITLE
Handle template names in update_model_templates input

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -209,7 +209,9 @@
   - `model_name: str` — имя существующей модели Anki, шаблоны которой нужно изменить.
   - `templates: Dict[str, CardTemplateSpec]` — новый набор шаблонов карточек. Ключ словаря должен
     совпадать с именем шаблона (`CardTemplateSpec.name`), а значения допускают как snake_case (`front`,
-    `back`, `name`), так и привычные для AnkiConnect ключи (`Front`, `Back`, `Name`).
+    `back`, `name`), так и привычные для AnkiConnect ключи (`Front`, `Back`, `Name`). Поле `name`
+    можно опустить: оно будет автоматически подставлено из ключа словаря, поэтому можно передавать
+    структуру напрямую из ответа `anki.model_info`.
 
 ### `UpdateModelStylingArgs`
 - **Используется в:** `anki.update_model_styling`.


### PR DESCRIPTION
## Summary
- auto-fill missing template names in UpdateModelTemplatesArgs using mapping keys
- keep mismatch validation in anki.update_model_templates while accepting payloads straight from model_info
- document the optional template name field and add regression tests for both success and conflict cases

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0485124b08330994ab07ca961421f