### PR TITLE
Fix README reference to anki.invoke

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@
 **Сервисные вызовы**
 - `anki.list_tags` — отдаёт все теги, используемые в базе. [Подробнее](docs/tools.md#инструмент-anki-list_tags)
 - `anki.sync` — инициирует синхронизацию с AnkiWeb. [Подробнее](docs/tools.md#инструмент-anki-sync)
-- `anki.invoke_action` — выполняет произвольный RPC AnkiConnect для редких сценариев.
+- `anki.invoke` — выполняет произвольный RPC AnkiConnect для редких сценариев. [Подробнее](docs/tools.md#anki.invoke)
 - `greet` — быстрый «пинг» для проверки соединения. [Подробнее](docs/tools.md#greet)
 - `search` — вызывает внешний поиск (например, webhook в n8n), возвращая результаты и курсор пагинации. [Подробнее](docs/tools.md#search)
 


### PR DESCRIPTION
## Summary
- update the service calls section in README to reference `anki.invoke`
- link the description to the detailed documentation for the tool

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d05efea054833082c5fcd5f2bba85f