### PR TITLE
docs: relocate update model styling payload

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -467,6 +467,19 @@
   - AnkiConnect вернёт ошибку, если модель не существует или в шаблоне CSS есть синтаксические ошибки, которые Anki не может обработать.
   - Убедитесь, что в CSS экранированы кавычки и обратные слэши, если запрос формируется вручную.
 
+Инструмент отправляет в AnkiConnect RPC `updateModelStyling` с полезной нагрузкой вида:
+
+```json
+{
+  "model": {
+    "name": "Поля для ChatGPT",
+    "styling": {
+      "css": ".card { font-family: 'Fira Code', monospace; }"
+    }
+  }
+}
+```
+
 #### Пример запроса
 
 ```json
@@ -503,19 +516,6 @@
     { "id": 5, "name": "Basic (and reversed card)" },
     { "id": 8, "name": "Cloze" }
   ]
-}
-```
-
-Инструмент отправляет в AnkiConnect RPC `updateModelStyling` с полезной нагрузкой вида:
-
-```json
-{
-  "model": {
-    "name": "Поля для ChatGPT",
-    "styling": {
-      "css": ".card { font-family: 'Fira Code', monospace; }"
-    }
-  }
 }
 ```
 


### PR DESCRIPTION
## Summary
- relocate the updateModelStyling payload description from the list models section to the update model styling section
- keep the list models documentation focused on listing models only

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d0653cceec8330b667eda7d3bd17cc