### PR TITLE
Refactor Anki service subsystems

### DIFF
--- a/anki_mcp/services/__init__.py
+++ b/anki_mcp/services/__init__.py
@@ -1,6 +1,6 @@
 """Прикладные сервисы MCP-сервера."""
 
-from . import anki, search
+from . import anki, client, media, notes, search
 
 
-__all__ = ["anki", "search"]
+__all__ = ["anki", "client", "media", "notes", "search"]

--- a/anki_mcp/services/anki.py
+++ b/anki_mcp/services/anki.py
@@ -1,426 +1,60 @@
-"""Прикладные сервисы для взаимодействия с Anki и обработкой заметок."""
+"""Совместимый фасад над специализированными подсистемами сервисов."""
 
 from __future__ import annotations
 
-import base64
-import hashlib
-import re
-import uuid
-from io import BytesIO
-from typing import Any, Dict, List, Mapping, Optional, Tuple
+from typing import Dict, List, Tuple
 
-import httpx
-from PIL import Image
-
-from ..compat import model_validate
 from .. import config
-from ..schemas import NoteInfo
 
+from . import client as client_services
+from . import media as media_services
+from . import notes as notes_services
 
-def __getattr__(name: str):  # pragma: no cover - simple module proxy
-    if name == "ANKI_URL":
-        return config.ANKI_URL
-    raise AttributeError(f"module 'anki_mcp.services.anki' has no attribute {name!r}")
-
-
-async def anki_call(
-    action: str,
-    params: Optional[Mapping[str, Any]] = None,
-    *,
-    version: int = 6,
-):
-    if not isinstance(action, str):
-        raise TypeError("action must be a string")
-    trimmed_action = action.strip()
-    if not trimmed_action:
-        raise ValueError("action must be a non-empty string")
-
-    if params is None:
-        normalized_params: Dict[str, Any] = {}
-    elif isinstance(params, dict):
-        normalized_params = dict(params)
-    elif isinstance(params, Mapping):
-        normalized_params = dict(params)
-    else:  # pragma: no cover - защитный хэндлинг типов
-        raise TypeError("params must be a mapping of argument names to values")
-
-    if isinstance(version, bool) or not isinstance(version, int):
-        raise TypeError("version must be an integer")
-
-    payload = {
-        "action": trimmed_action,
-        "version": version,
-        "params": normalized_params,
-    }
-    async with httpx.AsyncClient(timeout=25) as client:
-        response = await client.post(config.ANKI_URL, json=payload)
-        response.raise_for_status()
-        data = response.json()
-        if data.get("error"):
-            raise RuntimeError(f"Anki error: {data['error']}")
-        return data["result"]
-
-
-async def store_media_file(filename: str, data_b64: str):
-    return await anki_call("storeMediaFile", {"filename": filename, "data": data_b64})
-
-
-async def fetch_image_as_base64(url: str, max_side: int) -> str:
-    if max_side < 1:
-        raise ValueError("max_side must be at least 1")
-
-    async with httpx.AsyncClient(timeout=30, follow_redirects=True) as client:
-        response = await client.get(url)
-        response.raise_for_status()
-        content = response.content
-
-    try:
-        original = Image.open(BytesIO(content))
-        target_format = "JPEG"
-
-        if "A" in (original.getbands() or ()):  # RGBA/LA/etc.
-            rgba = original.convert("RGBA")
-            background = Image.new("RGB", rgba.size, (255, 255, 255))
-            alpha = rgba.getchannel("A")
-            background.paste(rgba, mask=alpha)
-            image = background
-        elif original.mode == "P" and "transparency" in original.info:
-            rgba = original.convert("RGBA")
-            background = Image.new("RGB", rgba.size, (255, 255, 255))
-            alpha = rgba.getchannel("A")
-            background.paste(rgba, mask=alpha)
-            image = background
-        elif original.mode != "RGB":
-            image = original.convert("RGB")
-        else:
-            image = original
-
-        width, height = image.size
-        scale = max(width, height) / max_side if max(width, height) > max_side else 1.0
-        if scale > 1.0:
-            new_width = max(1, round(width / scale))
-            new_height = max(1, round(height / scale))
-            image = image.resize((new_width, new_height))
-        buffer = BytesIO()
-        image.save(buffer, format=target_format, quality=85)
-        content = buffer.getvalue()
-    except Exception:
-        pass
-
-    return base64.b64encode(content).decode("ascii")
-
-
-IMG_TAG_TEMPLATE = '<div><img src="{src}" style="max-width:100%;height:auto"/></div>'
-
-
-def build_img_tag(filename: str) -> str:
-    return IMG_TAG_TEMPLATE.format(src=filename)
-
-
-def ensure_img_tag(existing: str, filename: str) -> str:
-    existing = existing or ""
-    tag = build_img_tag(filename)
-    if re.search(rf'src=["\']{re.escape(filename)}["\']', existing, re.IGNORECASE):
-        return existing
-
-    trimmed = existing.rstrip()
-    if not trimmed:
-        return tag
-    return f"{trimmed}\n\n{tag}"
-
-
-ANCHOR_TAG_RE = re.compile(r"<a\b[^>]*>.*?</a>", re.IGNORECASE | re.DOTALL)
-URL_RE = re.compile(r"(?P<url>https?://[^\s<>\"']+)", re.IGNORECASE)
-
-
-def auto_link_urls(text: str) -> str:
-    if not text:
-        return text or ""
-
-    anchors = [match.span() for match in ANCHOR_TAG_RE.finditer(text)]
-    if not anchors:
-        return URL_RE.sub(
-            lambda match: f'<a href="{match.group("url")}">{match.group("url")}</a>',
-            text,
-        )
-
-    def _replace(match: re.Match[str]) -> str:
-        start = match.start()
-        for span_start, span_end in anchors:
-            if span_start <= start < span_end:
-                return match.group("url")
-        url = match.group("url")
-        return f'<a href="{url}">{url}</a>'
-
-    return URL_RE.sub(_replace, text)
-
-
-DATA_URL_RE = re.compile(r"^data:image/([a-zA-Z0-9+.\-]+);base64,(.+)$", re.IGNORECASE)
-DATA_URL_INLINE_RE = re.compile(
-    r"data:image/([a-zA-Z0-9+.\-]+);base64,([a-zA-Z0-9+/=]+)", re.IGNORECASE
+_MODULE_EXPORTS: Tuple[object, ...] = (
+    client_services,
+    media_services,
+    notes_services,
 )
 
 
-def ext_from_mime(mime_subtype: str) -> str:
-    subtype = mime_subtype.lower()
-    if subtype in ("jpeg", "jpg", "pjpeg"):
-        return "jpg"
-    if subtype in ("png", "x-png"):
-        return "png"
-    if subtype in ("webp",):
-        return "webp"
-    if subtype in ("gif",):
-        return "gif"
-    return "png"
+def __getattr__(name: str):  # pragma: no cover - простой прокси
+    if name == "ANKI_URL":
+        return config.ANKI_URL
+    for module in _MODULE_EXPORTS:
+        if hasattr(module, name):
+            return getattr(module, name)
+    raise AttributeError(f"module 'anki_mcp.services.anki' has no attribute {name!r}")
 
 
-def sanitize_image_payload(payload: str) -> Tuple[str, Optional[str]]:
-    trimmed = (payload or "").strip()
-    if not trimmed:
-        raise ValueError("image payload is empty")
-
-    match = DATA_URL_RE.match(trimmed)
-    if match:
-        mime_subtype, b64_payload = match.group(1), match.group(2).strip()
-        try:
-            raw = base64.b64decode(b64_payload, validate=True)
-        except Exception as exc:  # pragma: no cover - error path
-            raise ValueError(f"invalid base64 image data: {exc}") from exc
-        clean_b64 = base64.b64encode(raw).decode("ascii")
-        return clean_b64, ext_from_mime(mime_subtype)
-
-    try:
-        raw = base64.b64decode(trimmed, validate=True)
-    except Exception as exc:  # pragma: no cover - error path
-        raise ValueError(f"invalid base64 image data: {exc}") from exc
-    clean_b64 = base64.b64encode(raw).decode("ascii")
-    return clean_b64, None
-
-
-async def process_data_urls_in_fields(
-    fields: Dict[str, str], results: List[dict], note_index: int
-):
-    for key, value in list(fields.items()):
-        if not isinstance(value, str):
-            continue
-
-        matches = list(DATA_URL_INLINE_RE.finditer(value))
-        if not matches:
-            trimmed = value.strip()
-            match = DATA_URL_RE.match(trimmed)
-            matches = [match] if match else []
-            if matches:
-                value = trimmed
-        if not matches:
-            continue
-
-        saved_files: List[str] = []
-        rebuilt: List[str] = []
-        cursor = 0
-
-        for match in matches:
-            data_url = match.group(0)
-            try:
-                clean_b64, ext_hint = sanitize_image_payload(data_url)
-                raw = base64.b64decode(clean_b64, validate=True)
-                digest = hashlib.sha1(raw).hexdigest()
-                mime_subtype = match.group(1) if match.lastindex else None
-                extension = ext_hint or (
-                    ext_from_mime(mime_subtype) if mime_subtype else "png"
-                )
-                filename = f"img_{digest}.{extension}"
-                await store_media_file(filename, clean_b64)
-                saved_files.append(filename)
-                results.append({"index": note_index, "info": f"data_url_saved:{key}->{filename}"})
-            except Exception as exc:
-                results.append({"index": note_index, "warn": f"data_url_failed:{key}: {exc}"})
-                rebuilt.append(value[cursor : match.end()])
-                cursor = match.end()
-                continue
-
-            rebuilt.append(value[cursor : match.start()])
-            cursor = match.end()
-
-        rebuilt.append(value[cursor:])
-        new_value = "".join(rebuilt)
-        clean_text = new_value.strip()
-        for filename in saved_files:
-            clean_text = ensure_img_tag(clean_text, filename)
-
-        fields[key] = clean_text
+def __dir__() -> List[str]:  # pragma: no cover - вспомогательный экспорт
+    dynamic: List[str] = []
+    for module in _MODULE_EXPORTS:
+        dynamic.extend(getattr(module, "__all__", []) or dir(module))
+    dynamic.extend(["ANKI_URL", "get_model_field_names", "get_model_fields_templates"])
+    return sorted(set(dynamic))
 
 
 async def get_model_fields_templates(
     model: str,
 ) -> Tuple[List[str], Dict[str, Dict[str, str]], str]:
-    fields = await anki_call("modelFieldNames", {"modelName": model})
-    templates = await anki_call("modelTemplates", {"modelName": model})
-    styling = await anki_call("modelStyling", {"modelName": model})
+    fields = await client_services.anki_call("modelFieldNames", {"modelName": model})
+    templates = await client_services.anki_call("modelTemplates", {"modelName": model})
+    styling = await client_services.anki_call("modelStyling", {"modelName": model})
     return fields, templates, styling.get("css", "")
 
 
 async def get_model_field_names(model: str) -> List[str]:
-    return await anki_call("modelFieldNames", {"modelName": model})
-
-
-def normalize_fields_for_model(
-    user_fields: Dict[str, str], model_fields: List[str]
-) -> Tuple[Dict[str, str], int, List[str]]:
-    normalized: Dict[str, str] = {}
-    lower_map = {key.lower(): key for key in user_fields.keys()}
-    matched_keys: List[str] = []
-    for model_field in model_fields:
-        key = lower_map.get(model_field.lower())
-        if key:
-            normalized[model_field] = user_fields.get(key, "")
-            matched_keys.append(key)
-        else:
-            normalized[model_field] = ""
-
-    unknown_fields = [key for key in user_fields.keys() if key not in matched_keys]
-    return normalized, len(matched_keys), sorted(unknown_fields)
-
-
-def normalize_and_validate_note_fields(
-    user_fields: Dict[str, str], model_fields: List[str]
-) -> Dict[str, str]:
-    fields, matched_count, unknown_fields = normalize_fields_for_model(
-        user_fields, model_fields
-    )
-
-    if not model_fields:
-        raise ValueError("Model has no fields configured")
-
-    if matched_count == 0 or not fields.get(model_fields[0]):
-        expected = ", ".join(repr(name) for name in model_fields)
-        provided = ", ".join(repr(name) for name in unknown_fields)
-        raise ValueError(
-            "Unknown note fields: "
-            f"[{provided}]"
-            f". Expected fields: [{expected}]. "
-            f"Ensure required field '{model_fields[0]}' is provided."
-        )
-
-    return fields
-
-
-def _normalize_note_fields_payload(raw_fields: Any) -> Dict[str, str]:
-    if not isinstance(raw_fields, dict):
-        return {}
-
-    normalized: Dict[str, str] = {}
-    for key, value in raw_fields.items():
-        if isinstance(value, dict) and "value" in value:
-            candidate = value.get("value")
-        else:
-            candidate = value
-
-        if candidate is None:
-            normalized_value = ""
-        elif isinstance(candidate, str):
-            normalized_value = candidate
-        else:
-            normalized_value = str(candidate)
-
-        normalized[str(key)] = normalized_value
-
-    return normalized
-
-
-def _normalize_note_tags(raw_tags: Any) -> List[str]:
-    if not isinstance(raw_tags, list):
-        return []
-
-    tags: List[str] = []
-    for tag in raw_tags:
-        if tag is None:
-            continue
-        if isinstance(tag, str):
-            trimmed = tag.strip()
-            if trimmed:
-                tags.append(trimmed)
-        else:
-            tags.append(str(tag))
-    return tags
-
-
-def _normalize_note_cards(raw_cards: Any) -> List[int]:
-    if not isinstance(raw_cards, list):
-        return []
-
-    cards: List[int] = []
-    for card in raw_cards:
-        if card is None:
-            continue
-        if isinstance(card, int):
-            cards.append(card)
-            continue
-        if isinstance(card, float):
-            cards.append(int(card))
-            continue
-        if isinstance(card, str):
-            stripped = card.strip()
-            if not stripped:
-                continue
-            try:
-                cards.append(int(stripped))
-            except ValueError:
-                continue
-    return cards
-
-
-def _normalize_note_entry(raw_note: Any, index: int) -> Optional[NoteInfo]:
-    if raw_note is None:
-        return None
-    if not isinstance(raw_note, dict):
-        raise ValueError(f"notesInfo[{index}] must be an object or null")
-
-    note_id_raw = raw_note.get("noteId")
-    if isinstance(note_id_raw, int):
-        note_id = note_id_raw
-    elif isinstance(note_id_raw, str):
-        stripped = note_id_raw.strip()
-        if not stripped:
-            raise ValueError(f"notesInfo[{index}].noteId is empty")
-        try:
-            note_id = int(stripped)
-        except ValueError as exc:
-            raise ValueError(
-                f"notesInfo[{index}].noteId must be an integer, got {note_id_raw!r}"
-            ) from exc
-    else:
-        raise ValueError(
-            f"notesInfo[{index}].noteId must be an integer, got {note_id_raw!r}"
-        )
-
-    payload = {
-        "noteId": note_id,
-        "modelName": raw_note.get("modelName"),
-        "deckName": raw_note.get("deckName"),
-        "tags": _normalize_note_tags(raw_note.get("tags")),
-        "fields": _normalize_note_fields_payload(raw_note.get("fields")),
-        "cards": _normalize_note_cards(raw_note.get("cards")),
-    }
-
-    return model_validate(NoteInfo, payload)
-
-
-def normalize_notes_info(raw_notes: Any) -> List[Optional[NoteInfo]]:
-    if not isinstance(raw_notes, list):
-        raise ValueError("notesInfo response must be a list")
-
-    normalized: List[Optional[NoteInfo]] = []
-    for index, raw_note in enumerate(raw_notes):
-        normalized.append(_normalize_note_entry(raw_note, index))
-    return normalized
+    return await client_services.anki_call("modelFieldNames", {"modelName": model})
 
 
 __all__ = [
     "ANKI_URL",
+    "ANCHOR_TAG_RE",
     "DATA_URL_INLINE_RE",
     "DATA_URL_RE",
     "IMG_TAG_TEMPLATE",
     "anki_call",
+    "auto_link_urls",
     "build_img_tag",
     "ensure_img_tag",
     "ext_from_mime",

--- a/anki_mcp/services/client.py
+++ b/anki_mcp/services/client.py
@@ -1,0 +1,61 @@
+"""Клиентские вызовы к AnkiConnect."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Mapping, Optional
+
+import httpx
+
+from .. import config
+
+
+async def anki_call(
+    action: str,
+    params: Optional[Mapping[str, Any]] = None,
+    *,
+    version: int = 6,
+):
+    """Выполнить RPC-вызов AnkiConnect.
+
+    Проводит базовую валидацию аргументов и проксирует запрос к серверу.
+    """
+
+    if not isinstance(action, str):
+        raise TypeError("action must be a string")
+    trimmed_action = action.strip()
+    if not trimmed_action:
+        raise ValueError("action must be a non-empty string")
+
+    if params is None:
+        normalized_params: Dict[str, Any] = {}
+    elif isinstance(params, dict):
+        normalized_params = dict(params)
+    elif isinstance(params, Mapping):
+        normalized_params = dict(params)
+    else:  # pragma: no cover - защитный хэндлинг типов
+        raise TypeError("params must be a mapping of argument names to values")
+
+    if isinstance(version, bool) or not isinstance(version, int):
+        raise TypeError("version must be an integer")
+
+    payload = {
+        "action": trimmed_action,
+        "version": version,
+        "params": normalized_params,
+    }
+    async with httpx.AsyncClient(timeout=25) as client:
+        response = await client.post(config.ANKI_URL, json=payload)
+        response.raise_for_status()
+        data = response.json()
+        if data.get("error"):
+            raise RuntimeError(f"Anki error: {data['error']}")
+        return data["result"]
+
+
+async def store_media_file(filename: str, data_b64: str):
+    """Сохранить файл мультимедиа через AnkiConnect."""
+
+    return await anki_call("storeMediaFile", {"filename": filename, "data": data_b64})
+
+
+__all__ = ["anki_call", "store_media_file", "httpx"]

--- a/anki_mcp/services/media.py
+++ b/anki_mcp/services/media.py
@@ -1,0 +1,220 @@
+"""Работа с мультимедийными данными и HTML-полями."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import re
+from io import BytesIO
+from typing import Dict, List, Optional, Tuple
+
+import httpx
+from PIL import Image
+
+from . import client as client_services
+
+
+async def store_media_file(filename: str, data_b64: str):
+    return await client_services.store_media_file(filename, data_b64)
+
+
+IMG_TAG_TEMPLATE = '<div><img src="{src}" style="max-width:100%;height:auto"/></div>'
+
+
+def build_img_tag(filename: str) -> str:
+    return IMG_TAG_TEMPLATE.format(src=filename)
+
+
+def ensure_img_tag(existing: str, filename: str) -> str:
+    existing = existing or ""
+    tag = build_img_tag(filename)
+    if re.search(rf'src=["\']{re.escape(filename)}["\']', existing, re.IGNORECASE):
+        return existing
+
+    trimmed = existing.rstrip()
+    if not trimmed:
+        return tag
+    return f"{trimmed}\n\n{tag}"
+
+
+ANCHOR_TAG_RE = re.compile(r"<a\b[^>]*>.*?</a>", re.IGNORECASE | re.DOTALL)
+URL_RE = re.compile(r"(?P<url>https?://[^\s<>\"']+)", re.IGNORECASE)
+
+
+def auto_link_urls(text: str) -> str:
+    if not text:
+        return text or ""
+
+    anchors = [match.span() for match in ANCHOR_TAG_RE.finditer(text)]
+    if not anchors:
+        return URL_RE.sub(
+            lambda match: f'<a href="{match.group("url")}">{match.group("url")}</a>',
+            text,
+        )
+
+    def _replace(match: re.Match[str]) -> str:
+        start = match.start()
+        for span_start, span_end in anchors:
+            if span_start <= start < span_end:
+                return match.group("url")
+        url = match.group("url")
+        return f'<a href="{url}">{url}</a>'
+
+    return URL_RE.sub(_replace, text)
+
+
+DATA_URL_RE = re.compile(r"^data:image/([a-zA-Z0-9+.\-]+);base64,(.+)$", re.IGNORECASE)
+DATA_URL_INLINE_RE = re.compile(
+    r"data:image/([a-zA-Z0-9+.\-]+);base64,([a-zA-Z0-9+/=]+)", re.IGNORECASE
+)
+
+
+def ext_from_mime(mime_subtype: str) -> str:
+    subtype = mime_subtype.lower()
+    if subtype in ("jpeg", "jpg", "pjpeg"):
+        return "jpg"
+    if subtype in ("png", "x-png"):
+        return "png"
+    if subtype in ("webp",):
+        return "webp"
+    if subtype in ("gif",):
+        return "gif"
+    return "png"
+
+
+async def fetch_image_as_base64(url: str, max_side: int) -> str:
+    if max_side < 1:
+        raise ValueError("max_side must be at least 1")
+
+    async with httpx.AsyncClient(timeout=30, follow_redirects=True) as client:
+        response = await client.get(url)
+        response.raise_for_status()
+        content = response.content
+
+    try:
+        original = Image.open(BytesIO(content))
+        target_format = "JPEG"
+
+        if "A" in (original.getbands() or ()):  # RGBA/LA/etc.
+            rgba = original.convert("RGBA")
+            background = Image.new("RGB", rgba.size, (255, 255, 255))
+            alpha = rgba.getchannel("A")
+            background.paste(rgba, mask=alpha)
+            image = background
+        elif original.mode == "P" and "transparency" in original.info:
+            rgba = original.convert("RGBA")
+            background = Image.new("RGB", rgba.size, (255, 255, 255))
+            alpha = rgba.getchannel("A")
+            background.paste(rgba, mask=alpha)
+            image = background
+        elif original.mode != "RGB":
+            image = original.convert("RGB")
+        else:
+            image = original
+
+        width, height = image.size
+        scale = max(width, height) / max_side if max(width, height) > max_side else 1.0
+        if scale > 1.0:
+            new_width = max(1, round(width / scale))
+            new_height = max(1, round(height / scale))
+            image = image.resize((new_width, new_height))
+        buffer = BytesIO()
+        image.save(buffer, format=target_format, quality=85)
+        content = buffer.getvalue()
+    except Exception:
+        pass
+
+    return base64.b64encode(content).decode("ascii")
+
+
+def sanitize_image_payload(payload: str) -> Tuple[str, Optional[str]]:
+    trimmed = (payload or "").strip()
+    if not trimmed:
+        raise ValueError("image payload is empty")
+
+    match = DATA_URL_RE.match(trimmed)
+    if match:
+        mime_subtype, b64_payload = match.group(1), match.group(2).strip()
+        try:
+            raw = base64.b64decode(b64_payload, validate=True)
+        except Exception as exc:  # pragma: no cover - error path
+            raise ValueError(f"invalid base64 image data: {exc}") from exc
+        clean_b64 = base64.b64encode(raw).decode("ascii")
+        return clean_b64, ext_from_mime(mime_subtype)
+
+    try:
+        raw = base64.b64decode(trimmed, validate=True)
+    except Exception as exc:  # pragma: no cover - error path
+        raise ValueError(f"invalid base64 image data: {exc}") from exc
+    clean_b64 = base64.b64encode(raw).decode("ascii")
+    return clean_b64, None
+
+
+async def process_data_urls_in_fields(
+    fields: Dict[str, str], results: List[dict], note_index: int
+):
+    for key, value in list(fields.items()):
+        if not isinstance(value, str):
+            continue
+
+        matches = list(DATA_URL_INLINE_RE.finditer(value))
+        if not matches:
+            trimmed = value.strip()
+            match = DATA_URL_RE.match(trimmed)
+            matches = [match] if match else []
+            if matches:
+                value = trimmed
+        if not matches:
+            continue
+
+        saved_files: List[str] = []
+        rebuilt: List[str] = []
+        cursor = 0
+
+        for match in matches:
+            data_url = match.group(0)
+            try:
+                clean_b64, ext_hint = sanitize_image_payload(data_url)
+                raw = base64.b64decode(clean_b64, validate=True)
+                digest = hashlib.sha1(raw).hexdigest()
+                mime_subtype = match.group(1) if match.lastindex else None
+                extension = ext_hint or (
+                    ext_from_mime(mime_subtype) if mime_subtype else "png"
+                )
+                filename = f"img_{digest}.{extension}"
+                await store_media_file(filename, clean_b64)
+                saved_files.append(filename)
+                results.append({"index": note_index, "info": f"data_url_saved:{key}->{filename}"})
+            except Exception as exc:
+                results.append({"index": note_index, "warn": f"data_url_failed:{key}: {exc}"})
+                rebuilt.append(value[cursor : match.end()])
+                cursor = match.end()
+                continue
+
+            rebuilt.append(value[cursor : match.start()])
+            cursor = match.end()
+
+        rebuilt.append(value[cursor:])
+        new_value = "".join(rebuilt)
+        clean_text = new_value.strip()
+        for filename in saved_files:
+            clean_text = ensure_img_tag(clean_text, filename)
+
+        fields[key] = clean_text
+
+
+__all__ = [
+    "ANCHOR_TAG_RE",
+    "DATA_URL_INLINE_RE",
+    "DATA_URL_RE",
+    "IMG_TAG_TEMPLATE",
+    "auto_link_urls",
+    "build_img_tag",
+    "ensure_img_tag",
+    "ext_from_mime",
+    "fetch_image_as_base64",
+    "httpx",
+    "process_data_urls_in_fields",
+    "store_media_file",
+    "sanitize_image_payload",
+]

--- a/anki_mcp/services/notes.py
+++ b/anki_mcp/services/notes.py
@@ -1,0 +1,167 @@
+"""Нормализация данных заметок Anki."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Tuple
+
+from ..compat import model_validate
+from ..schemas import NoteInfo
+
+
+def normalize_fields_for_model(
+    user_fields: Dict[str, str], model_fields: List[str]
+) -> Tuple[Dict[str, str], int, List[str]]:
+    normalized: Dict[str, str] = {}
+    lower_map = {key.lower(): key for key in user_fields.keys()}
+    matched_keys: List[str] = []
+    for model_field in model_fields:
+        key = lower_map.get(model_field.lower())
+        if key:
+            normalized[model_field] = user_fields.get(key, "")
+            matched_keys.append(key)
+        else:
+            normalized[model_field] = ""
+
+    unknown_fields = [key for key in user_fields.keys() if key not in matched_keys]
+    return normalized, len(matched_keys), sorted(unknown_fields)
+
+
+def normalize_and_validate_note_fields(
+    user_fields: Dict[str, str], model_fields: List[str]
+) -> Dict[str, str]:
+    fields, matched_count, unknown_fields = normalize_fields_for_model(
+        user_fields, model_fields
+    )
+
+    if not model_fields:
+        raise ValueError("Model has no fields configured")
+
+    if matched_count == 0 or not fields.get(model_fields[0]):
+        expected = ", ".join(repr(name) for name in model_fields)
+        provided = ", ".join(repr(name) for name in unknown_fields)
+        raise ValueError(
+            "Unknown note fields: "
+            f"[{provided}]"
+            f". Expected fields: [{expected}]. "
+            f"Ensure required field '{model_fields[0]}' is provided."
+        )
+
+    return fields
+
+
+def _normalize_note_fields_payload(raw_fields: Any) -> Dict[str, str]:
+    if not isinstance(raw_fields, dict):
+        return {}
+
+    normalized: Dict[str, str] = {}
+    for key, value in raw_fields.items():
+        if isinstance(value, dict) and "value" in value:
+            candidate = value.get("value")
+        else:
+            candidate = value
+
+        if candidate is None:
+            normalized_value = ""
+        elif isinstance(candidate, str):
+            normalized_value = candidate
+        else:
+            normalized_value = str(candidate)
+
+        normalized[str(key)] = normalized_value
+
+    return normalized
+
+
+def _normalize_note_tags(raw_tags: Any) -> List[str]:
+    if not isinstance(raw_tags, list):
+        return []
+
+    tags: List[str] = []
+    for tag in raw_tags:
+        if tag is None:
+            continue
+        if isinstance(tag, str):
+            trimmed = tag.strip()
+            if trimmed:
+                tags.append(trimmed)
+        else:
+            tags.append(str(tag))
+    return tags
+
+
+def _normalize_note_cards(raw_cards: Any) -> List[int]:
+    if not isinstance(raw_cards, list):
+        return []
+
+    cards: List[int] = []
+    for card in raw_cards:
+        if card is None:
+            continue
+        if isinstance(card, int):
+            cards.append(card)
+            continue
+        if isinstance(card, float):
+            cards.append(int(card))
+            continue
+        if isinstance(card, str):
+            stripped = card.strip()
+            if not stripped:
+                continue
+            try:
+                cards.append(int(stripped))
+            except ValueError:
+                continue
+    return cards
+
+
+def _normalize_note_entry(raw_note: Any, index: int) -> Optional[NoteInfo]:
+    if raw_note is None:
+        return None
+    if not isinstance(raw_note, dict):
+        raise ValueError(f"notesInfo[{index}] must be an object or null")
+
+    note_id_raw = raw_note.get("noteId")
+    if isinstance(note_id_raw, int):
+        note_id = note_id_raw
+    elif isinstance(note_id_raw, str):
+        stripped = note_id_raw.strip()
+        if not stripped:
+            raise ValueError(f"notesInfo[{index}].noteId is empty")
+        try:
+            note_id = int(stripped)
+        except ValueError as exc:
+            raise ValueError(
+                f"notesInfo[{index}].noteId must be an integer, got {note_id_raw!r}"
+            ) from exc
+    else:
+        raise ValueError(
+            f"notesInfo[{index}].noteId must be an integer, got {note_id_raw!r}"
+        )
+
+    payload = {
+        "noteId": note_id,
+        "modelName": raw_note.get("modelName"),
+        "deckName": raw_note.get("deckName"),
+        "tags": _normalize_note_tags(raw_note.get("tags")),
+        "fields": _normalize_note_fields_payload(raw_note.get("fields")),
+        "cards": _normalize_note_cards(raw_note.get("cards")),
+    }
+
+    return model_validate(NoteInfo, payload)
+
+
+def normalize_notes_info(raw_notes: Any) -> List[Optional[NoteInfo]]:
+    if not isinstance(raw_notes, list):
+        raise ValueError("notesInfo response must be a list")
+
+    normalized: List[Optional[NoteInfo]] = []
+    for index, raw_note in enumerate(raw_notes):
+        normalized.append(_normalize_note_entry(raw_note, index))
+    return normalized
+
+
+__all__ = [
+    "normalize_and_validate_note_fields",
+    "normalize_fields_for_model",
+    "normalize_notes_info",
+]

--- a/server.py
+++ b/server.py
@@ -68,8 +68,13 @@ from anki_mcp import (
 from anki_mcp import config as _config
 from anki_mcp.actions import search
 from anki_mcp.manifest import _format_mcp_info
-from anki_mcp.services import anki as anki_services
-from anki_mcp.services import search as search_services
+from anki_mcp.services import (
+    anki as anki_services,
+    client as client_services,
+    media as media_services,
+    notes as notes_services,
+    search as search_services,
+)
 from anki_mcp.tools import (
     add_from_model,
     add_notes,
@@ -125,17 +130,22 @@ def __dir__():
 # Обеспечиваем доступ к httpx для тестовых заглушек.
 httpx = search_services.httpx
 
+# Переэкспорт специализированных сервисов.
+anki_client = client_services
+anki_media = media_services
+anki_notes = notes_services
+
 # Переэкспорт сервисных функций, если они использовались напрямую.
-anki_call = anki_services.anki_call
-store_media_file = anki_services.store_media_file
-fetch_image_as_base64 = anki_services.fetch_image_as_base64
-normalize_fields_for_model = anki_services.normalize_fields_for_model
-normalize_and_validate_note_fields = anki_services.normalize_and_validate_note_fields
-process_data_urls_in_fields = anki_services.process_data_urls_in_fields
-sanitize_image_payload = anki_services.sanitize_image_payload
-ensure_img_tag = anki_services.ensure_img_tag
-build_img_tag = anki_services.build_img_tag
-normalize_notes_info = anki_services.normalize_notes_info
+anki_call = client_services.anki_call
+store_media_file = client_services.store_media_file
+fetch_image_as_base64 = media_services.fetch_image_as_base64
+normalize_fields_for_model = notes_services.normalize_fields_for_model
+normalize_and_validate_note_fields = notes_services.normalize_and_validate_note_fields
+process_data_urls_in_fields = media_services.process_data_urls_in_fields
+sanitize_image_payload = media_services.sanitize_image_payload
+ensure_img_tag = media_services.ensure_img_tag
+build_img_tag = media_services.build_img_tag
+normalize_notes_info = notes_services.normalize_notes_info
 get_model_fields_templates = anki_services.get_model_fields_templates
 get_model_field_names = anki_services.get_model_field_names
 
@@ -220,6 +230,9 @@ __all__ = [
     "save_deck_config",
     "invoke_action",
     "sync",
+    "anki_client",
+    "anki_media",
+    "anki_notes",
     "anki_call",
     "app",
     "uuid",

--- a/tests/test_add_from_model_unknown_fields.py
+++ b/tests/test_add_from_model_unknown_fields.py
@@ -87,7 +87,7 @@ async def test_add_from_model_unknown_fields_raise(monkeypatch):
             raise AssertionError("modelStyling should not be called")
         raise AssertionError(f"Unexpected action: {action}")
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     note = NoteInput(fields={"Question": "What is new?"})
 
@@ -122,7 +122,7 @@ async def test_add_from_model_accepts_flat_fields(monkeypatch):
             raise AssertionError("modelStyling should not be called")
         raise AssertionError(f"Unexpected action: {action}")
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     items = [NoteInput(Front="Question?", Back="Answer!")]
 
@@ -155,7 +155,7 @@ async def test_add_from_model_accepts_plain_dict(monkeypatch):
             raise AssertionError("modelStyling should not be called")
         raise AssertionError(f"Unexpected action: {action}")
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     result = await add_from_model.fn(
         deck="Deck",
@@ -190,7 +190,7 @@ async def test_add_from_model_normalizes_note_input_tags(monkeypatch):
             raise AssertionError("modelStyling should not be called")
         raise AssertionError(f"Unexpected action: {action}")
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     note = NoteInput(Front="Q", Back="A", tags="auto")
 
@@ -220,7 +220,7 @@ async def test_add_notes_accepts_flat_fields(monkeypatch):
             return [777]
         raise AssertionError(f"Unexpected action: {action}")
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     args = AddNotesArgs(deck="Deck", model="Basic", notes=[{"Front": "Q", "Back": "A"}])
 
@@ -262,7 +262,7 @@ async def test_add_from_model_respects_note_level_deck_and_model(monkeypatch):
             raise AssertionError("modelStyling should not be called")
         raise AssertionError(f"Unexpected action: {action}")
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     default_note = NoteInput(Front="Q1", Back="A1")
     override_note = NoteInput(
@@ -318,7 +318,7 @@ async def test_add_notes_respects_note_level_deck_and_model(monkeypatch):
             return [333, 444]
         raise AssertionError(f"Unexpected action: {action}")
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     args = AddNotesArgs(
         deck="Deck",

--- a/tests/test_anki_invoke.py
+++ b/tests/test_anki_invoke.py
@@ -61,7 +61,7 @@ async def test_invoke_action_passes_payload(monkeypatch):
         payloads.append({"action": action, "params": params, "version": version})
         return {"echo": len(payloads)}
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     first_args = InvokeActionArgs(action="multi", params={"actions": []}, version=7)
     first_result = await _unwrap(invoke_action)(first_args)

--- a/tests/test_cards_info.py
+++ b/tests/test_cards_info.py
@@ -123,7 +123,7 @@ def test_cards_info_normalizes_payload(monkeypatch):
             }
         ]
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     cards_info_fn = getattr(cards_info, "fn", cards_info)
     result = asyncio.run(cards_info_fn(CardsInfoArgs(card_ids=[111, 222])))
@@ -146,7 +146,7 @@ def test_cards_info_rejects_invalid_entry(monkeypatch):
         assert action == "cardsInfo"
         return [None]
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     cards_info_fn = getattr(cards_info, "fn", cards_info)
 

--- a/tests/test_cards_to_notes.py
+++ b/tests/test_cards_to_notes.py
@@ -99,7 +99,7 @@ def test_cards_to_notes_normalizes_response(monkeypatch):
         assert params == {"cards": [111, 222]}
         return ["555", 777]
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     cards_to_notes_fn = getattr(cards_to_notes, "fn", cards_to_notes)
     result = asyncio.run(cards_to_notes_fn({"cardIds": ["111", 222]}))
@@ -114,7 +114,7 @@ def test_cards_to_notes_rejects_invalid_response(monkeypatch):
     async def fake_anki_call(action, params):
         return "unexpected"
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     cards_to_notes_fn = getattr(cards_to_notes, "fn", cards_to_notes)
 

--- a/tests/test_create_deck.py
+++ b/tests/test_create_deck.py
@@ -16,7 +16,7 @@ def test_create_deck_payload(monkeypatch):
         assert params == {"deck": "Inbox"}
         return {"status": "ok"}
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     create_deck_fn = deck_helpers._unwrap_tool(create_deck)
     args = CreateDeckArgs(deck="Inbox")
@@ -30,7 +30,7 @@ def test_create_deck_validation_error(monkeypatch):
     async def forbidden_call(action, params):
         raise AssertionError("anki_call should not be invoked on validation errors")
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", forbidden_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", forbidden_call)
 
     create_deck_fn = deck_helpers._unwrap_tool(create_deck)
 
@@ -44,7 +44,7 @@ def test_create_deck_propagates_anki_errors(monkeypatch):
     async def fake_anki_call(action, params):
         raise RuntimeError("boom")
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     create_deck_fn = deck_helpers._unwrap_tool(create_deck)
 

--- a/tests/test_create_model.py
+++ b/tests/test_create_model.py
@@ -65,7 +65,7 @@ async def test_create_model_payload(monkeypatch):
         captured["params"] = params
         return {"created": True}
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     args = CreateModelArgs(
         model_name="Custom QA",
@@ -116,7 +116,7 @@ async def test_create_model_rejects_reserved_option(monkeypatch):
     async def fake_anki_call(action, params):  # pragma: no cover - should not be called
         raise AssertionError("anki_call must not be invoked on invalid input")
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     with pytest.raises(ValueError) as exc:
         await _unwrap(create_model)(
@@ -136,7 +136,7 @@ async def test_create_model_conflicting_is_cloze(monkeypatch):
     async def fake_anki_call(action, params):  # pragma: no cover - should not run
         raise AssertionError("anki_call should not be used when validation fails")
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     with pytest.raises(ValueError) as exc:
         await _unwrap(create_model)(

--- a/tests/test_deck_config.py
+++ b/tests/test_deck_config.py
@@ -63,7 +63,7 @@ def test_get_deck_config_payload(monkeypatch):
         assert params == {"deck": "Default"}
         return SAMPLE_DECK_CONFIG_RAW
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     get_deck_config_fn = deck_helpers._unwrap_tool(get_deck_config)
     args = GetDeckConfigArgs(deck="Default")
@@ -82,7 +82,7 @@ def test_get_deck_config_invalid_response(monkeypatch):
         assert action == "getDeckConfig"
         return "not-a-mapping"
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     get_deck_config_fn = deck_helpers._unwrap_tool(get_deck_config)
 
@@ -107,7 +107,7 @@ def test_save_deck_config_updates_and_assigns(monkeypatch):
             return {"applied": True}
         raise AssertionError(f"unexpected action {action}")
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     save_deck_config_fn = deck_helpers._unwrap_tool(save_deck_config)
     args = SaveDeckConfigArgs(config=config, deck="Inbox")
@@ -135,7 +135,7 @@ def test_save_deck_config_requires_id_for_assignment(monkeypatch):
         assert action == "saveDeckConfig"
         return None
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     save_deck_config_fn = deck_helpers._unwrap_tool(save_deck_config)
 
@@ -150,7 +150,7 @@ def test_save_deck_config_validation_error(monkeypatch):
     async def forbidden_call(action, params):
         raise AssertionError("anki_call should not be invoked on validation errors")
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", forbidden_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", forbidden_call)
 
     save_deck_config_fn = deck_helpers._unwrap_tool(save_deck_config)
 

--- a/tests/test_deck_tools.py
+++ b/tests/test_deck_tools.py
@@ -111,7 +111,7 @@ def test_list_decks_normalizes_response(monkeypatch):
         assert params == {}
         return {"Default": 1, "Custom": "1700000000000"}
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     list_decks_fn = _unwrap_tool(list_decks)
     result = asyncio.run(list_decks_fn())
@@ -127,7 +127,7 @@ def test_list_decks_handles_empty_mapping(monkeypatch):
         assert params == {}
         return {}
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     list_decks_fn = _unwrap_tool(list_decks)
     result = asyncio.run(list_decks_fn())
@@ -144,7 +144,7 @@ def test_rename_deck_payload(monkeypatch):
         assert params == {"oldName": "Inbox", "newName": "Archive"}
         return "ok"
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     rename_deck_fn = _unwrap_tool(rename_deck)
     args = RenameDeckArgs(old_name="Inbox", new_name="Archive")
@@ -163,7 +163,7 @@ def test_delete_decks_payload(monkeypatch):
         assert params == {"decks": ["Inbox", "Temp"], "cardsToo": True}
         return None
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     delete_decks_fn = _unwrap_tool(delete_decks)
     args = DeleteDecksArgs(decks=["Inbox", "Temp"], cards_too=True)

--- a/tests/test_dedup_key.py
+++ b/tests/test_dedup_key.py
@@ -59,7 +59,7 @@ async def test_add_from_model_includes_dedup_key(monkeypatch):
             return [101, None]
         raise AssertionError(f"Unexpected action: {action}")
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     items = [
         NoteInput(fields={"Front": "Q1", "Back": "A1"}, dedup_key="first"),
@@ -91,7 +91,7 @@ async def test_add_notes_includes_dedup_key(monkeypatch):
             return [202, None]
         raise AssertionError(f"Unexpected action: {action}")
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     args = AddNotesArgs(
         deck="Deck",
@@ -127,7 +127,7 @@ async def test_add_notes_lowercase_fields_empty_front(monkeypatch):
             raise AssertionError("addNotes should not be called when fields invalid")
         raise AssertionError(f"Unexpected action: {action}")
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     args = AddNotesArgs(
         deck="Deck",

--- a/tests/test_delete_notes.py
+++ b/tests/test_delete_notes.py
@@ -57,7 +57,7 @@ async def test_delete_notes_calls_anki_and_handles_none(monkeypatch):
         assert action == "deleteNotes"
         return None
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     args = DeleteNotesArgs(noteIds=[1, 2, 3])
     delete_fn = getattr(delete_notes, "fn", delete_notes)
@@ -75,7 +75,7 @@ async def test_delete_notes_normalizes_list_response(monkeypatch):
         assert params == {"notes": [10, 20, 30, 40, 50]}
         return [True, False, None, {"status": "missing"}, {"status": "ok"}]
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     args = DeleteNotesArgs(noteIds=[10, 20, 30, 40, 50])
     delete_fn = getattr(delete_notes, "fn", delete_notes)
@@ -92,7 +92,7 @@ async def test_delete_notes_handles_mapping_counts(monkeypatch):
         assert params == {"notes": [7, 8, 9, 10]}
         return {"deleted": 3, "missing": 1}
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     args = DeleteNotesArgs(noteIds=[7, 8, 9, 10])
     delete_fn = getattr(delete_notes, "fn", delete_notes)

--- a/tests/test_find_cards.py
+++ b/tests/test_find_cards.py
@@ -102,7 +102,7 @@ def test_find_cards_accepts_mapping(monkeypatch):
         assert params == {"query": "deck:Default"}
         return [111, "222", 333.0, " 444 "]
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     find_cards_fn = getattr(find_cards, "fn", find_cards)
     result = asyncio.run(
@@ -120,7 +120,7 @@ def test_find_cards_rejects_non_list_response(monkeypatch):
         assert action == "findCards"
         return "oops"
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     find_cards_fn = getattr(find_cards, "fn", find_cards)
 
@@ -133,7 +133,7 @@ def test_find_cards_rejects_boolean_id(monkeypatch):
         assert action == "findCards"
         return [True, 42]
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     find_cards_fn = getattr(find_cards, "fn", find_cards)
 

--- a/tests/test_find_notes.py
+++ b/tests/test_find_notes.py
@@ -119,7 +119,7 @@ def test_find_notes_with_limit_and_offset(monkeypatch):
             ]
         raise AssertionError(f"Unexpected call: {action}")
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     args = FindNotesArgs(query="deck:Default", limit=2, offset=1)
     find_notes_fn = getattr(find_notes, "fn", find_notes)
@@ -140,7 +140,7 @@ def test_find_notes_without_results(monkeypatch):
         assert action == "findNotes"
         return []
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     args = FindNotesArgs(query="deck:Empty")
     find_notes_fn = getattr(find_notes, "fn", find_notes)
@@ -155,7 +155,7 @@ def test_find_notes_rejects_invalid_response(monkeypatch):
     async def fake_anki_call(action, params):
         return "oops"
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     find_notes_fn = getattr(find_notes, "fn", find_notes)
 

--- a/tests/test_image_data_url.py
+++ b/tests/test_image_data_url.py
@@ -86,8 +86,8 @@ async def test_add_from_model_sanitizes_data_url(monkeypatch):
             return [123]
         raise AssertionError(f"unexpected action: {action}")
 
-    monkeypatch.setattr("anki_mcp.services.anki.store_media_file", fake_store_media_file)
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.store_media_file", fake_store_media_file)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
     monkeypatch.setattr(server.uuid, "uuid4", lambda: DummyUUID("abc123"))
 
     image = server.ImageSpec(image_base64=data_url, target_field="Back")
@@ -113,7 +113,7 @@ async def test_process_data_urls_accepts_mixed_case_prefix(monkeypatch):
         stored["filename"] = filename
         stored["data"] = data_b64
 
-    monkeypatch.setattr("anki_mcp.services.anki.store_media_file", fake_store_media_file)
+    monkeypatch.setattr("anki_mcp.services.client.store_media_file", fake_store_media_file)
 
     original_value = f"Before text {data_url}"
     fields = {"Back": original_value}
@@ -157,8 +157,8 @@ async def test_data_url_and_images_share_same_html(monkeypatch):
             return [456]
         raise AssertionError(f"unexpected action: {action}")
 
-    monkeypatch.setattr("anki_mcp.services.anki.store_media_file", fake_store_media_file)
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.store_media_file", fake_store_media_file)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
     monkeypatch.setattr(server.uuid, "uuid4", lambda: DummyUUID("imguuid"))
 
     fields = {"Back": f"Existing {data_url}"}
@@ -204,8 +204,8 @@ async def test_add_from_model_target_field_is_case_insensitive(monkeypatch):
             return [555]
         raise AssertionError(f"unexpected action: {action}")
 
-    monkeypatch.setattr("anki_mcp.services.anki.store_media_file", fake_store_media_file)
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.store_media_file", fake_store_media_file)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
     monkeypatch.setattr(server.uuid, "uuid4", lambda: DummyUUID("case-img"))
 
     image = server.ImageSpec(image_base64="data:image/png;base64,Zm9v", target_field="back")
@@ -238,7 +238,7 @@ async def test_add_from_model_unknown_target_field_warn(monkeypatch):
             return [4321]
         raise AssertionError(f"unexpected action: {action}")
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     image = server.ImageSpec(image_base64="data:image/png;base64,Zm9v", target_field="Summary")
     note = server.NoteInput(fields={"Front": "Question"}, images=[image])
@@ -283,9 +283,9 @@ async def test_note_input_accepts_url_alias(monkeypatch):
             return [987]
         raise AssertionError(f"unexpected action: {action}")
 
-    monkeypatch.setattr("anki_mcp.services.anki.fetch_image_as_base64", fake_fetch_image)
-    monkeypatch.setattr("anki_mcp.services.anki.store_media_file", fake_store_media_file)
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.media.fetch_image_as_base64", fake_fetch_image)
+    monkeypatch.setattr("anki_mcp.services.client.store_media_file", fake_store_media_file)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
     monkeypatch.setattr(server.uuid, "uuid4", lambda: DummyUUID("img-alias"))
 
     note = server.NoteInput(

--- a/tests/test_image_target_field_normalization.py
+++ b/tests/test_image_target_field_normalization.py
@@ -70,8 +70,8 @@ def _setup_common_monkeypatches(monkeypatch, captured, *, allow_template_calls: 
     async def fake_store_media_file(filename: str, data_b64: str):
         captured.setdefault("storeMedia", []).append({"filename": filename, "data": data_b64})
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
-    monkeypatch.setattr("anki_mcp.services.anki.store_media_file", fake_store_media_file)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.store_media_file", fake_store_media_file)
     monkeypatch.setattr(server.uuid, "uuid4", lambda: SimpleNamespace(hex="img-alias"))
 
 

--- a/tests/test_list_models.py
+++ b/tests/test_list_models.py
@@ -63,7 +63,7 @@ def test_list_models_normalizes_and_sorts(monkeypatch):
         assert params == {}
         return {"Cloze": "8", "Basic": 1, "Basic (and reversed card)": 5}
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     list_models_fn = _unwrap_tool(list_models)
     result = asyncio.run(list_models_fn())
@@ -83,7 +83,7 @@ def test_list_models_invalid_payload(monkeypatch):
         assert params == {}
         return ["Basic", "Cloze"]
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     list_models_fn = _unwrap_tool(list_models)
 

--- a/tests/test_list_tags.py
+++ b/tests/test_list_tags.py
@@ -60,7 +60,7 @@ def test_list_tags_normalizes_and_sorts(monkeypatch):
         assert params == {}
         return [" travel ", "English", "Pronunciation", "english", "Travel"]
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     list_tags_fn = _unwrap_tool(list_tags)
     result = asyncio.run(list_tags_fn())
@@ -76,7 +76,7 @@ def test_list_tags_invalid_payload(monkeypatch):
         assert params == {}
         return {"not": "a list"}
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     list_tags_fn = _unwrap_tool(list_tags)
 

--- a/tests/test_media_tools.py
+++ b/tests/test_media_tools.py
@@ -63,7 +63,7 @@ async def test_get_media_returns_payload(monkeypatch):
         assert params == {"filename": "sound.wav"}
         return payload
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     args = MediaRequest(filename="sound.wav")
     result = await _unwrap(get_media)(args)
@@ -78,7 +78,7 @@ async def test_get_media_raises_file_not_found(monkeypatch):
     async def fake_anki_call(action, params):
         raise RuntimeError("Media file not found")
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     with pytest.raises(FileNotFoundError):
         await _unwrap(get_media)(MediaRequest(filename="missing.png"))
@@ -91,7 +91,7 @@ async def test_delete_media_reports_status(monkeypatch):
         assert params == {"filename": "audio/hello.mp3"}
         return None
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     result = await _unwrap(delete_media)(DeleteMediaArgs(filename="audio/hello.mp3"))
 
@@ -109,7 +109,7 @@ async def test_delete_media_handles_partial_failures(monkeypatch):
         assert params == {"filename": "batch.bin"}
         return [True, False, None]
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     result = await _unwrap(delete_media)(DeleteMediaArgs(filename="batch.bin"))
 
@@ -123,7 +123,7 @@ async def test_delete_media_raises_file_not_found(monkeypatch):
     async def fake_anki_call(action, params):
         raise RuntimeError("No such file or directory")
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     with pytest.raises(FileNotFoundError):
         await _unwrap(delete_media)(DeleteMediaArgs(filename="ghost.jpg"))

--- a/tests/test_note_info.py
+++ b/tests/test_note_info.py
@@ -113,7 +113,7 @@ def test_note_info_normalizes_payload(monkeypatch):
             None,
         ]
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     args = NoteInfoArgs(note_ids=[111, 222])
     note_info_fn = getattr(note_info, "fn", note_info)
@@ -144,7 +144,7 @@ def test_note_info_propagates_errors(monkeypatch):
     async def fake_anki_call(action, params):
         raise RuntimeError("notesInfo failed")
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     with pytest.raises(RuntimeError):
         note_info_fn = getattr(note_info, "fn", note_info)

--- a/tests/test_notes_to_cards.py
+++ b/tests/test_notes_to_cards.py
@@ -101,7 +101,7 @@ def test_notes_to_cards_normalizes_response(monkeypatch):
         assert params == {"notes": [101, 202]}
         return {"101": ["301", 302], 202: None}
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     notes_to_cards_fn = getattr(notes_to_cards, "fn", notes_to_cards)
     result = asyncio.run(notes_to_cards_fn({"noteIds": ["101", 202]}))
@@ -116,7 +116,7 @@ def test_notes_to_cards_invalid_response(monkeypatch):
     async def fake_anki_call(action, params):
         return "unexpected"
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     notes_to_cards_fn = getattr(notes_to_cards, "fn", notes_to_cards)
 

--- a/tests/test_server_environment.py
+++ b/tests/test_server_environment.py
@@ -135,7 +135,7 @@ async def test_add_tools_follow_reloaded_defaults(monkeypatch):
             raise AssertionError(f"Unexpected action for add_from_model: {action}")
 
         monkeypatch.setattr(
-            "anki_mcp.services.anki.anki_call", fake_anki_call_model
+            "anki_mcp.services.client.anki_call", fake_anki_call_model
         )
 
         note = module.NoteInput(Front="Q", Back="A")
@@ -160,7 +160,7 @@ async def test_add_tools_follow_reloaded_defaults(monkeypatch):
             raise AssertionError(f"Unexpected action for add_notes: {action}")
 
         monkeypatch.setattr(
-            "anki_mcp.services.anki.anki_call", fake_anki_call_notes
+            "anki_mcp.services.client.anki_call", fake_anki_call_notes
         )
 
         second_note = module.NoteInput(Front="Q2", Back="A2")

--- a/tests/test_services_client.py
+++ b/tests/test_services_client.py
@@ -1,0 +1,41 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from anki_mcp.services import client
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_anki_call_rejects_non_string_action():
+    with pytest.raises(TypeError):
+        await client.anki_call(123)  # type: ignore[arg-type]
+
+
+@pytest.mark.anyio
+async def test_store_media_file_delegates(monkeypatch):
+    captured = {}
+
+    async def fake_anki_call(action, params=None, *, version=6):
+        captured["payload"] = (action, params, version)
+        return {"ok": True}
+
+    monkeypatch.setattr(client, "anki_call", fake_anki_call)
+
+    result = await client.store_media_file("image.png", "ZGF0YQ==")
+
+    assert result == {"ok": True}
+    assert captured["payload"] == (
+        "storeMediaFile",
+        {"filename": "image.png", "data": "ZGF0YQ=="},
+        6,
+    )

--- a/tests/test_services_media.py
+++ b/tests/test_services_media.py
@@ -1,0 +1,71 @@
+import base64
+import hashlib
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from anki_mcp.services import media
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def test_ensure_img_tag_adds_when_missing():
+    result = media.ensure_img_tag("", "picture.png")
+    assert "picture.png" in result
+    assert result.count("picture.png") == 1
+
+
+def test_auto_link_urls_skips_existing_anchor():
+    text = 'см. <a href="https://example.com">https://example.com</a>'
+    assert media.auto_link_urls(text) == text
+
+
+def test_sanitize_image_payload_data_url():
+    raw = base64.b64encode(b"payload").decode("ascii")
+    clean, ext = media.sanitize_image_payload(f"data:image/png;base64,{raw}")
+    assert clean == raw
+    assert ext == "png"
+
+
+@pytest.mark.anyio
+async def test_process_data_urls_in_fields(monkeypatch):
+    raw = b"image-bytes"
+    payload = base64.b64encode(raw).decode("ascii")
+    data_url = f"data:image/png;base64,{payload}"
+    fields = {"Front": f"Question {data_url} text"}
+    results: list[dict] = []
+
+    saved = {}
+
+    async def fake_store(filename, data):
+        saved["filename"] = filename
+        saved["data"] = data
+
+    monkeypatch.setattr(media, "store_media_file", fake_store)
+
+    await media.process_data_urls_in_fields(fields, results, 0)
+
+    digest = hashlib.sha1(raw).hexdigest()
+    expected_filename = f"img_{digest}.png"
+
+    assert saved["filename"] == expected_filename
+    assert saved["data"] == payload
+    assert results == [
+        {"index": 0, "info": f"data_url_saved:Front->{expected_filename}"}
+    ]
+    assert expected_filename in fields["Front"]
+    assert "<img" in fields["Front"]
+
+
+@pytest.mark.anyio
+async def test_fetch_image_as_base64_rejects_small_max_side():
+    with pytest.raises(ValueError):
+        await media.fetch_image_as_base64("http://example.com", 0)

--- a/tests/test_services_notes.py
+++ b/tests/test_services_notes.py
@@ -1,0 +1,52 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from anki_mcp.schemas import NoteInfo
+from anki_mcp.services import notes
+
+
+def test_normalize_fields_for_model_matches_case_insensitive():
+    normalized, matched, unknown = notes.normalize_fields_for_model(
+        {"front": "Question", "Extra": ""}, ["Front", "Back"]
+    )
+    assert normalized == {"Front": "Question", "Back": ""}
+    assert matched == 1
+    assert unknown == ["Extra"]
+
+
+def test_normalize_and_validate_note_fields_requires_primary():
+    with pytest.raises(ValueError):
+        notes.normalize_and_validate_note_fields({}, ["Front", "Back"])
+
+
+def test_normalize_notes_info_converts_entries():
+    raw_notes = [
+        {
+            "noteId": "123",
+            "modelName": "Basic",
+            "deckName": "Default",
+            "tags": ["tag1", ""],
+            "fields": {"Front": {"value": "Hello"}, "Back": None},
+            "cards": ["10", 11],
+        }
+    ]
+
+    normalized = notes.normalize_notes_info(raw_notes)
+
+    assert len(normalized) == 1
+    note = normalized[0]
+    assert isinstance(note, NoteInfo)
+    assert note.note_id == 123
+    assert note.fields == {"Front": "Hello", "Back": ""}
+    assert note.cards == [10, 11]
+
+
+def test_normalize_notes_info_rejects_non_list():
+    with pytest.raises(ValueError):
+        notes.normalize_notes_info({})

--- a/tests/test_sources_autolink.py
+++ b/tests/test_sources_autolink.py
@@ -64,7 +64,7 @@ async def test_add_from_model_autolinks_sources(monkeypatch):
             return [321]
         raise AssertionError(f"Unexpected action: {action}")
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     note = NoteInput(fields={"Front": "Q", "Back": "A", "Sources": "https://example.com"})
 
@@ -90,7 +90,7 @@ async def test_add_notes_autolinks_sources(monkeypatch):
             return [654]
         raise AssertionError(f"Unexpected action: {action}")
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     args = AddNotesArgs(
         deck="Deck",

--- a/tests/test_store_media.py
+++ b/tests/test_store_media.py
@@ -64,7 +64,7 @@ async def test_store_media_accepts_aliases(monkeypatch):
         return {"stored": True}
 
     monkeypatch.setattr(
-        "anki_mcp.services.anki.store_media_file", fake_store_media_file
+        "anki_mcp.services.client.store_media_file", fake_store_media_file
     )
 
     args = {"filename": "audio/test.mp3", "data": encoded}
@@ -81,7 +81,7 @@ async def test_store_media_rejects_invalid_base64(monkeypatch):
         pytest.fail("store_media_file не должен вызываться для некорректного Base64")
 
     monkeypatch.setattr(
-        "anki_mcp.services.anki.store_media_file", fail_store_media_file
+        "anki_mcp.services.client.store_media_file", fail_store_media_file
     )
 
     with pytest.raises(ValueError):
@@ -98,7 +98,7 @@ async def test_store_media_propagates_service_errors(monkeypatch):
         raise RuntimeError("AnkiConnect unavailable")
 
     monkeypatch.setattr(
-        "anki_mcp.services.anki.store_media_file", fake_store_media_file
+        "anki_mcp.services.client.store_media_file", fake_store_media_file
     )
 
     with pytest.raises(RuntimeError):

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -60,7 +60,7 @@ async def test_sync_invokes_rpc_and_normalizes_none(monkeypatch):
         calls.append((action, params))
         return None
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     result = await _unwrap(sync)()
 
@@ -75,7 +75,7 @@ async def test_sync_wraps_boolean_result(monkeypatch):
         assert params == {}
         return False
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     result = await _unwrap(sync)()
 
@@ -87,7 +87,7 @@ async def test_sync_converts_invalid_params_error(monkeypatch):
     async def fake_anki_call(action, params):
         raise RuntimeError("Anki error: invalid auth token")
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     with pytest.raises(ValueError, match="invalid auth token"):
         await _unwrap(sync)()
@@ -98,7 +98,7 @@ async def test_sync_preserves_system_errors(monkeypatch):
     async def fake_anki_call(action, params):
         raise RuntimeError("Anki error: collection is locked")
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     with pytest.raises(RuntimeError, match="collection is locked"):
         await _unwrap(sync)()

--- a/tests/test_update_model_styling.py
+++ b/tests/test_update_model_styling.py
@@ -64,7 +64,7 @@ async def test_update_model_styling_payload(monkeypatch):
         captured["params"] = params
         return {"updated": True}
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     args = UpdateModelStylingArgs(
         model_name="Поля для ChatGPT",
@@ -92,7 +92,7 @@ async def test_update_model_styling_accepts_mappings(monkeypatch):
         captured["params"] = params
         return None
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     payload = {"modelName": "Custom QA", "css": None}
 
@@ -113,7 +113,7 @@ async def test_update_model_styling_rejects_invalid_input(monkeypatch):
     async def fake_anki_call(action, params):  # pragma: no cover - should not run
         raise AssertionError("anki_call must not be invoked on invalid input")
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     with pytest.raises(ValueError) as exc:
         await _unwrap(update_model_styling)({"model_name": "  ", "css": "body {}"})

--- a/tests/test_update_model_templates.py
+++ b/tests/test_update_model_templates.py
@@ -65,7 +65,7 @@ async def test_update_model_templates_payload(monkeypatch):
         captured["params"] = params
         return {"updated": True}
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     args = UpdateModelTemplatesArgs(
         model_name="Поля для ChatGPT",
@@ -100,7 +100,7 @@ async def test_update_model_templates_rejects_mismatched_names(monkeypatch):
     async def fake_anki_call(action, params):  # pragma: no cover - should not run
         raise AssertionError("anki_call must not be invoked on invalid input")
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     args = UpdateModelTemplatesArgs(
         model_name="Поля для ChatGPT",
@@ -128,7 +128,7 @@ async def test_update_model_templates_accepts_mappings(monkeypatch):
         captured["params"] = params
         return None
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     payload = {
         "modelName": "Custom QA",
@@ -167,7 +167,7 @@ async def test_update_model_templates_accepts_model_info_payload(monkeypatch):
         captured["params"] = params
         return {"ok": True}
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     payload = {
         "modelName": "Custom QA",
@@ -201,7 +201,7 @@ async def test_update_model_templates_rejects_conflicting_name(monkeypatch):
     async def fake_anki_call(action, params):  # pragma: no cover - should not run
         raise AssertionError("anki_call must not be invoked on invalid input")
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
 
     payload = {
         "modelName": "Custom QA",

--- a/tests/test_update_notes.py
+++ b/tests/test_update_notes.py
@@ -95,12 +95,12 @@ async def test_update_notes_normalizes_fields_and_calls_actions(monkeypatch):
         process_calls[note_index] += 1
         results.append({"index": note_index, "info": "processed"})
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
     monkeypatch.setattr(
-        "anki_mcp.services.anki.normalize_fields_for_model", fake_normalize
+        "anki_mcp.services.notes.normalize_fields_for_model", fake_normalize
     )
     monkeypatch.setattr(
-        "anki_mcp.services.anki.process_data_urls_in_fields", fake_process
+        "anki_mcp.services.media.process_data_urls_in_fields", fake_process
     )
 
     note = NoteUpdate(
@@ -153,16 +153,16 @@ async def test_update_notes_handles_images(monkeypatch):
     def fake_sanitize(payload):
         return "CLEAN", "png"
 
-    monkeypatch.setattr("anki_mcp.services.anki.anki_call", fake_anki_call)
-    monkeypatch.setattr("anki_mcp.services.anki.store_media_file", fake_store_media)
+    monkeypatch.setattr("anki_mcp.services.client.anki_call", fake_anki_call)
+    monkeypatch.setattr("anki_mcp.services.client.store_media_file", fake_store_media)
     monkeypatch.setattr(
-        "anki_mcp.services.anki.sanitize_image_payload", fake_sanitize
+        "anki_mcp.services.media.sanitize_image_payload", fake_sanitize
     )
     async def fake_process(fields, results, note_index):
         return None
 
     monkeypatch.setattr(
-        "anki_mcp.services.anki.process_data_urls_in_fields", fake_process
+        "anki_mcp.services.media.process_data_urls_in_fields", fake_process
     )
 
     note = NoteUpdate(


### PR DESCRIPTION
## Summary
- вынес RPC-вызовы AnkiConnect, обработку медиа и нормализацию заметок в новые модули `client`, `media` и `notes`, обновив фасад `anki` и экспорт в `server` для обратной совместимости
- обновил инструменты и тесты на использование новых сервисных модулей и добавил отдельные unit-тесты для каждого из них

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d06a8ea16883309c88a54d056a6542