### PR TITLE
Refactor Anki tools into domain modules

### DIFF
--- a/anki_mcp/tools/__init__.py
+++ b/anki_mcp/tools/__init__.py
@@ -1,34 +1,35 @@
 """Пакет с MCP-инструментами."""
 
-from .anki import (
+from .decks import (
+    create_deck,
+    delete_decks,
+    get_deck_config,
+    list_decks,
+    list_tags,
+    rename_deck,
+    save_deck_config,
+)
+from .media import delete_media, get_media, store_media
+from .models import (
+    create_model,
+    list_models,
+    model_info,
+    update_model_styling,
+    update_model_templates,
+)
+from .notes import (
     add_from_model,
     add_notes,
     cards_info,
     cards_to_notes,
-    notes_to_cards,
-    create_deck,
-    create_model,
-    delete_decks,
-    delete_media,
     delete_notes,
     find_cards,
     find_notes,
-    get_media,
-    invoke_action,
-    sync,
-    list_models,
-    list_decks,
-    list_tags,
-    get_deck_config,
-    save_deck_config,
-    model_info,
     note_info,
-    rename_deck,
-    store_media,
-    update_model_styling,
-    update_model_templates,
+    notes_to_cards,
     update_notes,
 )
+from .sync import invoke_action, sync
 from .misc import greet
 
 

--- a/anki_mcp/tools/decks.py
+++ b/anki_mcp/tools/decks.py
@@ -1,0 +1,209 @@
+"""Инструменты Anki, связанные с колодами."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Mapping, Union
+
+from .. import app
+from ..compat import model_validate
+from ..schemas import (
+    CreateDeckArgs,
+    DeckConfig,
+    DeckInfo,
+    DeleteDecksArgs,
+    GetDeckConfigArgs,
+    ListDecksResponse,
+    ListTagsResponse,
+    RenameDeckArgs,
+    SaveDeckConfigArgs,
+)
+from ..services import client as anki_client
+
+
+def _model_dump(instance: Any, *, by_alias: bool = False, exclude_none: bool = False) -> Dict[str, Any]:
+    if hasattr(instance, "model_dump"):
+        return instance.model_dump(by_alias=by_alias, exclude_none=exclude_none)
+    if hasattr(instance, "dict"):
+        return instance.dict(by_alias=by_alias, exclude_none=exclude_none)
+    raise TypeError("instance must be a Pydantic model")
+
+
+@app.tool(name="anki.list_decks")
+async def list_decks() -> List[DeckInfo]:
+    raw_decks = await anki_client.anki_call("deckNamesAndIds", {})
+
+    if raw_decks is None:
+        return []
+
+    if not isinstance(raw_decks, Mapping):
+        raise ValueError("deckNamesAndIds response must be a mapping of deck names to ids")
+
+    deck_infos: List[DeckInfo] = []
+    for name, deck_id in raw_decks.items():
+        if not isinstance(name, str):
+            raise ValueError(f"deckNamesAndIds returned invalid deck name: {name!r}")
+
+        if isinstance(deck_id, bool):
+            raise ValueError(
+                f"deckNamesAndIds returned non-integer deck id for {name!r}: {deck_id!r}"
+            )
+
+        try:
+            normalized_id = int(deck_id)
+        except (TypeError, ValueError):
+            raise ValueError(
+                f"deckNamesAndIds returned non-integer deck id for {name!r}: {deck_id!r}"
+            ) from None
+
+        deck_infos.append(DeckInfo(id=normalized_id, name=name))
+
+    response = ListDecksResponse(decks=deck_infos)
+    return response.decks
+
+
+@app.tool(name="anki.list_tags")
+async def list_tags() -> ListTagsResponse:
+    try:
+        raw_tags = await anki_client.anki_call("getTags", {})
+    except RuntimeError as exc:
+        raise ValueError(f"AnkiConnect error: {exc}") from exc
+
+    if raw_tags is None:
+        tags: List[str] = []
+    else:
+        if isinstance(raw_tags, (str, bytes)):
+            raise ValueError("getTags response must be a sequence of strings")
+
+        if isinstance(raw_tags, Mapping):
+            raise ValueError("getTags response must be a sequence of strings")
+
+        try:
+            iterator = iter(raw_tags)
+        except TypeError as exc:  # pragma: no cover - защитный хендлинг
+            raise ValueError("getTags response must be a sequence of strings") from exc
+
+        tags = []
+        for index, tag in enumerate(iterator):
+            if not isinstance(tag, str):
+                raise ValueError(
+                    f"getTags returned non-string value at index {index}: {tag!r}"
+                )
+
+            stripped = tag.strip()
+            if not stripped:
+                raise ValueError(f"getTags returned empty tag at index {index}")
+
+            tags.append(stripped)
+
+    unique: Dict[str, str] = {}
+    for name in tags:
+        key = name.casefold()
+        unique.setdefault(key, name)
+
+    unique_sorted = sorted(unique.values(), key=lambda name: (name.casefold(), name))
+
+    return ListTagsResponse(tags=unique_sorted)
+
+
+@app.tool(name="anki.create_deck")
+async def create_deck(
+    args: Union[CreateDeckArgs, Mapping[str, Any]]
+) -> Any:
+    if isinstance(args, CreateDeckArgs):
+        normalized = args
+    else:
+        try:
+            normalized = model_validate(CreateDeckArgs, args)
+        except Exception as exc:
+            raise ValueError(f"Invalid create_deck arguments: {exc}") from exc
+
+    payload = {"deck": normalized.deck}
+    return await anki_client.anki_call("createDeck", payload)
+
+
+@app.tool(name="anki.get_deck_config")
+async def get_deck_config(
+    args: Union[GetDeckConfigArgs, Mapping[str, Any]]
+) -> DeckConfig:
+    if isinstance(args, GetDeckConfigArgs):
+        normalized = args
+    else:
+        try:
+            normalized = model_validate(GetDeckConfigArgs, args)
+        except Exception as exc:
+            raise ValueError(f"Invalid get_deck_config arguments: {exc}") from exc
+
+    payload = {"deck": normalized.deck}
+    raw_config = await anki_client.anki_call("getDeckConfig", payload)
+
+    try:
+        return model_validate(DeckConfig, raw_config)
+    except Exception as exc:  # pragma: no cover - depends on validation paths
+        raise ValueError(f"Invalid getDeckConfig response: {exc}") from exc
+
+
+@app.tool(name="anki.save_deck_config")
+async def save_deck_config(
+    args: Union[SaveDeckConfigArgs, Mapping[str, Any]]
+) -> Mapping[str, Any]:
+    if isinstance(args, SaveDeckConfigArgs):
+        normalized = args
+    else:
+        try:
+            normalized = model_validate(SaveDeckConfigArgs, args)
+        except Exception as exc:
+            raise ValueError(f"Invalid save_deck_config arguments: {exc}") from exc
+
+    config_payload = _model_dump(
+        normalized.config, by_alias=True, exclude_none=True
+    )
+    save_result = await anki_client.anki_call(
+        "saveDeckConfig", {"config": config_payload}
+    )
+
+    response: Dict[str, Any] = {
+        "save_result": save_result,
+    }
+
+    config_id = normalized.config.id
+    if config_id is not None:
+        response["configId"] = config_id
+
+    deck_name = normalized.deck
+    if deck_name:
+        if config_id is None:
+            raise ValueError(
+                "Deck config must include id to be assigned to a deck"
+            )
+
+        set_payload = {"deck": deck_name, "configId": config_id}
+        set_result = await anki_client.anki_call("setDeckConfigId", set_payload)
+        response.update({
+            "deck": deck_name,
+            "set_result": set_result,
+        })
+
+    return response
+
+
+@app.tool(name="anki.rename_deck")
+async def rename_deck(args: RenameDeckArgs):
+    payload = {"oldName": args.old_name, "newName": args.new_name}
+    return await anki_client.anki_call("renameDeck", payload)
+
+
+@app.tool(name="anki.delete_decks")
+async def delete_decks(args: DeleteDecksArgs):
+    payload = {"decks": list(args.decks), "cardsToo": bool(args.cards_too)}
+    return await anki_client.anki_call("deleteDecks", payload)
+
+
+__all__ = [
+    "list_decks",
+    "list_tags",
+    "create_deck",
+    "get_deck_config",
+    "save_deck_config",
+    "rename_deck",
+    "delete_decks",
+]

--- a/anki_mcp/tools/media.py
+++ b/anki_mcp/tools/media.py
@@ -1,0 +1,120 @@
+"""Инструменты работы с медиа."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+from typing import Any, Dict, Mapping, Optional, Union
+
+from .. import app
+from ..compat import model_validate
+from ..schemas import DeleteMediaArgs, MediaRequest, MediaResponse, StoreMediaArgs
+from ..services import client as anki_client
+
+
+def _normalize_media_error(filename: str, exc: Exception) -> Exception:
+    message = str(exc)
+    lowered = message.lower()
+    markers = (
+        "not found",
+        "does not exist",
+        "no such file",
+        "missing",
+    )
+    if any(marker in lowered for marker in markers):
+        return FileNotFoundError(f"Media file {filename!r} not found")
+    return exc
+
+
+def _calculate_media_size(data_base64: str) -> Optional[int]:
+    try:
+        raw = base64.b64decode(data_base64, validate=True)
+    except (binascii.Error, ValueError):
+        try:
+            raw = base64.b64decode(data_base64, validate=False)
+        except Exception:
+            return None
+    return len(raw)
+
+
+@app.tool(name="anki.get_media")
+async def get_media(args: MediaRequest) -> MediaResponse:
+    try:
+        raw_base64 = await anki_client.anki_call(
+            "retrieveMediaFile", {"filename": args.filename}
+        )
+    except Exception as exc:  # pragma: no cover - конкретные ошибки проверяются тестами
+        normalized_exc = _normalize_media_error(args.filename, exc)
+        if normalized_exc is exc:
+            raise
+        raise normalized_exc from exc
+
+    if not isinstance(raw_base64, str):
+        raise ValueError("retrieveMediaFile response must be a base64 string")
+
+    size_bytes = _calculate_media_size(raw_base64)
+    return MediaResponse(
+        filename=args.filename,
+        data_base64=raw_base64,
+        size_bytes=size_bytes,
+    )
+
+
+@app.tool(name="anki.store_media")
+async def store_media(
+    args: Union[StoreMediaArgs, Mapping[str, Any]]
+) -> Dict[str, Any]:
+    if isinstance(args, StoreMediaArgs):
+        normalized = args
+    else:
+        try:
+            normalized = model_validate(StoreMediaArgs, args)
+        except Exception as exc:
+            raise ValueError(f"Invalid store_media arguments: {exc}") from exc
+
+    try:
+        try:
+            base64.b64decode(normalized.data_base64, validate=True)
+        except (binascii.Error, ValueError):
+            base64.b64decode(normalized.data_base64, validate=False)
+    except (binascii.Error, ValueError) as exc:
+        raise ValueError("data_base64 must be valid Base64-encoded string") from exc
+
+    anki_response = await anki_client.store_media_file(
+        normalized.filename, normalized.data_base64
+    )
+
+    return {
+        "filename": normalized.filename,
+        "anki_response": anki_response,
+    }
+
+
+@app.tool(name="anki.delete_media")
+async def delete_media(args: DeleteMediaArgs) -> Dict[str, Any]:
+    try:
+        raw_response = await anki_client.anki_call(
+            "deleteMediaFile", {"filename": args.filename}
+        )
+    except Exception as exc:  # pragma: no cover - конкретные ошибки проверяются тестами
+        normalized_exc = _normalize_media_error(args.filename, exc)
+        if normalized_exc is exc:
+            raise
+        raise normalized_exc from exc
+
+    deleted: bool
+    if isinstance(raw_response, Mapping):
+        deleted = bool(raw_response.get("deleted", True))
+    elif isinstance(raw_response, list):
+        deleted = all(bool(item) for item in raw_response)
+    else:
+        deleted = raw_response in (None, True)
+
+    return {
+        "filename": args.filename,
+        "deleted": deleted,
+        "anki_response": raw_response,
+    }
+
+
+__all__ = ["get_media", "store_media", "delete_media"]

--- a/anki_mcp/tools/models.py
+++ b/anki_mcp/tools/models.py
@@ -1,0 +1,203 @@
+"""Инструменты Anki, связанные с моделями."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Mapping, Optional, Union
+
+from .. import app, config
+from ..compat import model_validate
+from ..schemas import (
+    CardTemplateSpec,
+    CreateModelArgs,
+    CreateModelResult,
+    ListModelsResponse,
+    ModelInfo,
+    ModelSummary,
+    UpdateModelStylingArgs,
+    UpdateModelTemplatesArgs,
+)
+from ..services import anki as anki_services
+from ..services import client as anki_client
+
+
+def _normalize_template(template: CardTemplateSpec) -> Dict[str, str]:
+    return {
+        "Name": template.name,
+        "Front": template.front,
+        "Back": template.back,
+    }
+
+
+@app.tool(name="anki.create_model")
+async def create_model(
+    args: Union[CreateModelArgs, Mapping[str, Any]]
+) -> CreateModelResult:
+    if isinstance(args, CreateModelArgs):
+        normalized = args
+    else:
+        try:
+            normalized = model_validate(CreateModelArgs, args)
+        except Exception as exc:
+            raise ValueError(f"Invalid create_model arguments: {exc}") from exc
+
+    reserved = {"modelName", "inOrderFields", "cardTemplates", "css"}
+    extra_options = dict(normalized.options)
+    for key in extra_options:
+        if key in reserved:
+            raise ValueError(
+                f"options cannot override reserved parameter {key!r}"
+            )
+
+    payload = {
+        "modelName": normalized.model_name,
+        "inOrderFields": normalized.in_order_fields,
+        "cardTemplates": [
+            _normalize_template(template) for template in normalized.card_templates
+        ],
+        "css": normalized.css,
+    }
+
+    if normalized.is_cloze is not None:
+        existing = extra_options.get("isCloze")
+        if existing is not None and existing != normalized.is_cloze:
+            raise ValueError(
+                "is_cloze conflicts with options['isCloze'] value"
+            )
+        payload["isCloze"] = normalized.is_cloze
+        extra_options["isCloze"] = normalized.is_cloze
+
+    payload.update(extra_options)
+
+    anki_response = await anki_client.anki_call("createModel", payload)
+
+    return CreateModelResult(
+        model_name=normalized.model_name,
+        in_order_fields=normalized.in_order_fields,
+        card_templates=list(normalized.card_templates),
+        css=normalized.css,
+        options=extra_options,
+        anki_response=anki_response,
+    )
+
+
+@app.tool(name="anki.update_model_templates")
+async def update_model_templates(
+    args: Union[UpdateModelTemplatesArgs, Mapping[str, Any]]
+) -> Any:
+    if isinstance(args, UpdateModelTemplatesArgs):
+        normalized = args
+    else:
+        try:
+            normalized = model_validate(UpdateModelTemplatesArgs, args)
+        except Exception as exc:
+            raise ValueError(
+                f"Invalid update_model_templates arguments: {exc}"
+            ) from exc
+
+    templates_payload: Dict[str, Dict[str, str]] = {}
+    for key, template in normalized.templates.items():
+        template_name = template.name
+        if not template_name:
+            raise ValueError("Template name must be a non-empty string")
+        key_stripped = key.strip()
+        if key_stripped and key_stripped != template_name:
+            raise ValueError(
+                f"Template mapping key {key!r} must match template name {template_name!r}"
+            )
+        if template_name in templates_payload:
+            raise ValueError(f"Duplicate template definition for {template_name!r}")
+        templates_payload[template_name] = {
+            "Front": template.front,
+            "Back": template.back,
+        }
+
+    payload = {
+        "model": {
+            "name": normalized.model_name,
+            "templates": templates_payload,
+        }
+    }
+
+    return await anki_client.anki_call("updateModelTemplates", payload)
+
+
+@app.tool(name="anki.update_model_styling")
+async def update_model_styling(
+    args: Union[UpdateModelStylingArgs, Mapping[str, Any]]
+) -> Any:
+    if isinstance(args, UpdateModelStylingArgs):
+        normalized = args
+    else:
+        try:
+            normalized = model_validate(UpdateModelStylingArgs, args)
+        except Exception as exc:
+            raise ValueError(
+                f"Invalid update_model_styling arguments: {exc}"
+            ) from exc
+
+    payload = {
+        "model": {
+            "name": normalized.model_name,
+            "styling": {"css": normalized.css},
+        }
+    }
+
+    return await anki_client.anki_call("updateModelStyling", payload)
+
+
+@app.tool(name="anki.list_models")
+async def list_models() -> ListModelsResponse:
+    raw_models = await anki_client.anki_call("modelNamesAndIds", {})
+
+    if raw_models is None:
+        return ListModelsResponse()
+
+    if not isinstance(raw_models, Mapping):
+        raise ValueError(
+            "modelNamesAndIds response must be a mapping of model names to ids"
+        )
+
+    model_summaries: List[ModelSummary] = []
+    for name, model_id in raw_models.items():
+        if not isinstance(name, str):
+            raise ValueError(
+                f"modelNamesAndIds returned invalid model name: {name!r}"
+            )
+
+        if isinstance(model_id, bool):
+            raise ValueError(
+                "modelNamesAndIds returned non-integer model id "
+                f"for {name!r}: {model_id!r}"
+            )
+
+        try:
+            normalized_id = int(model_id)
+        except (TypeError, ValueError):
+            raise ValueError(
+                "modelNamesAndIds returned non-integer model id "
+                f"for {name!r}: {model_id!r}"
+            ) from None
+
+        model_summaries.append(ModelSummary(id=normalized_id, name=name))
+
+    sorted_models = sorted(
+        model_summaries, key=lambda model: (model.name.casefold(), model.name)
+    )
+
+    return ListModelsResponse(models=sorted_models)
+
+
+@app.tool(name="anki.model_info")
+async def model_info(model: Optional[str] = None) -> ModelInfo:
+    target_model = model or config.DEFAULT_MODEL
+    fields, templates, css = await anki_services.get_model_fields_templates(target_model)
+    return ModelInfo(model=target_model, fields=fields, templates=templates, styling=css)
+
+
+__all__ = [
+    "create_model",
+    "update_model_templates",
+    "update_model_styling",
+    "list_models",
+    "model_info",
+]

--- a/anki_mcp/tools/sync.py
+++ b/anki_mcp/tools/sync.py
@@ -1,0 +1,83 @@
+"""Инструменты общего назначения и синхронизации."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Mapping
+
+from .. import app
+from ..schemas import InvokeActionArgs
+from ..services import client as anki_client
+
+
+@app.tool(name="anki.invoke")
+async def invoke_action(args: InvokeActionArgs) -> Any:
+    params_payload: Dict[str, Any]
+    if args.params is None:
+        params_payload = {}
+    elif isinstance(args.params, dict):
+        params_payload = dict(args.params)
+    elif isinstance(args.params, Mapping):
+        params_payload = dict(args.params)
+    else:
+        raise TypeError("params must be a mapping of argument names to values")
+
+    if args.version is None:
+        version = 6
+    elif isinstance(args.version, bool) or not isinstance(args.version, int):
+        raise TypeError("version must be an integer")
+    else:
+        version = args.version
+
+    payload = {
+        "action": args.action,
+        "version": version,
+        "params": params_payload,
+    }
+
+    result = await anki_client.anki_call(
+        payload["action"], payload["params"], version=payload["version"]
+    )
+    return result
+
+
+_SYNC_VALUE_ERROR_KEYWORDS = (
+    "invalid",
+    "missing",
+    "empty",
+    "required",
+    "unknown",
+    "no such",
+    "not found",
+    "please provide",
+    "must ",
+    "should ",
+)
+
+
+@app.tool(name="anki.sync")
+async def sync() -> Mapping[str, Any]:
+    try:
+        result = await anki_client.anki_call("sync", {})
+    except RuntimeError as exc:
+        detail = str(exc)
+        if detail.lower().startswith("anki error:"):
+            detail = detail.split(":", 1)[1].strip() or detail
+        lowered = detail.lower()
+        message = f"Не удалось выполнить синхронизацию Anki: {detail}"
+        if any(keyword in lowered for keyword in _SYNC_VALUE_ERROR_KEYWORDS):
+            raise ValueError(message) from exc
+        raise RuntimeError(message) from exc
+
+    if result is None:
+        return {"synced": True}
+
+    if isinstance(result, bool):
+        return {"synced": bool(result)}
+
+    if isinstance(result, Mapping):
+        return dict(result)
+
+    return {"result": result}
+
+
+__all__ = ["invoke_action", "sync"]

--- a/tests/test_add_from_model_unknown_fields.py
+++ b/tests/test_add_from_model_unknown_fields.py
@@ -63,7 +63,8 @@ ROOT = Path(__file__).resolve().parent.parent
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from server import AddNotesArgs, NoteInput, add_from_model, add_notes
+from anki_mcp import AddNotesArgs, NoteInput
+from anki_mcp.tools.notes import add_from_model, add_notes
 
 
 @pytest.fixture

--- a/tests/test_anki_invoke.py
+++ b/tests/test_anki_invoke.py
@@ -41,7 +41,8 @@ ROOT = Path(__file__).resolve().parent.parent
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from server import InvokeActionArgs, invoke_action  # noqa: E402
+from anki_mcp import InvokeActionArgs  # noqa: E402
+from anki_mcp.tools.sync import invoke_action  # noqa: E402
 
 
 def _unwrap(tool):

--- a/tests/test_cards_info.py
+++ b/tests/test_cards_info.py
@@ -90,7 +90,8 @@ ROOT = Path(__file__).resolve().parent.parent
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from server import CardInfo, CardsInfoArgs, cards_info
+from anki_mcp import CardInfo, CardsInfoArgs
+from anki_mcp.tools.notes import cards_info
 
 
 def test_cards_info_normalizes_payload(monkeypatch):

--- a/tests/test_cards_to_notes.py
+++ b/tests/test_cards_to_notes.py
@@ -90,7 +90,8 @@ ROOT = Path(__file__).resolve().parent.parent
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from server import CardsToNotesArgs, CardsToNotesResponse, cards_to_notes
+from anki_mcp import CardsToNotesArgs, CardsToNotesResponse
+from anki_mcp.tools.notes import cards_to_notes
 
 
 def test_cards_to_notes_normalizes_response(monkeypatch):

--- a/tests/test_create_deck.py
+++ b/tests/test_create_deck.py
@@ -4,7 +4,8 @@ import pytest
 
 import test_deck_tools as deck_helpers
 
-from server import CreateDeckArgs, create_deck
+from anki_mcp import CreateDeckArgs
+from anki_mcp.tools.decks import create_deck
 
 
 def test_create_deck_payload(monkeypatch):

--- a/tests/test_create_model.py
+++ b/tests/test_create_model.py
@@ -40,11 +40,8 @@ ROOT = Path(__file__).resolve().parent.parent
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from server import (  # noqa: E402
-    CardTemplateSpec,
-    CreateModelArgs,
-    create_model,
-)
+from anki_mcp import CardTemplateSpec, CreateModelArgs  # noqa: E402
+from anki_mcp.tools.models import create_model  # noqa: E402
 
 
 @pytest.fixture

--- a/tests/test_deck_config.py
+++ b/tests/test_deck_config.py
@@ -4,13 +4,8 @@ import pytest
 
 import test_deck_tools as deck_helpers
 
-from server import (
-    DeckConfig,
-    GetDeckConfigArgs,
-    SaveDeckConfigArgs,
-    get_deck_config,
-    save_deck_config,
-)
+from anki_mcp import DeckConfig, GetDeckConfigArgs, SaveDeckConfigArgs
+from anki_mcp.tools.decks import get_deck_config, save_deck_config
 
 
 SAMPLE_DECK_CONFIG_RAW = {

--- a/tests/test_deck_tools.py
+++ b/tests/test_deck_tools.py
@@ -88,14 +88,8 @@ ROOT = Path(__file__).resolve().parent.parent
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from server import (
-    DeleteDecksArgs,
-    DeckInfo,
-    RenameDeckArgs,
-    delete_decks,
-    list_decks,
-    rename_deck,
-)
+from anki_mcp import DeleteDecksArgs, DeckInfo, RenameDeckArgs
+from anki_mcp.tools.decks import delete_decks, list_decks, rename_deck
 
 
 def _unwrap_tool(func):

--- a/tests/test_dedup_key.py
+++ b/tests/test_dedup_key.py
@@ -36,7 +36,8 @@ ROOT = Path(__file__).resolve().parent.parent
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from server import AddNotesArgs, NoteInput, add_from_model, add_notes
+from anki_mcp import AddNotesArgs, NoteInput
+from anki_mcp.tools.notes import add_from_model, add_notes
 
 
 @pytest.fixture

--- a/tests/test_delete_notes.py
+++ b/tests/test_delete_notes.py
@@ -40,7 +40,8 @@ ROOT = Path(__file__).resolve().parent.parent
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from server import DeleteNotesArgs, delete_notes  # noqa: E402  # pylint: disable=wrong-import-position
+from anki_mcp import DeleteNotesArgs  # noqa: E402  # pylint: disable=wrong-import-position
+from anki_mcp.tools.notes import delete_notes  # noqa: E402  # pylint: disable=wrong-import-position
 
 
 @pytest.fixture

--- a/tests/test_find_cards.py
+++ b/tests/test_find_cards.py
@@ -90,7 +90,8 @@ ROOT = Path(__file__).resolve().parent.parent
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from server import FindCardsArgs, FindCardsResponse, find_cards
+from anki_mcp import FindCardsArgs, FindCardsResponse
+from anki_mcp.tools.notes import find_cards
 
 
 def test_find_cards_accepts_mapping(monkeypatch):

--- a/tests/test_find_notes.py
+++ b/tests/test_find_notes.py
@@ -90,7 +90,8 @@ ROOT = Path(__file__).resolve().parent.parent
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from server import FindNotesArgs, FindNotesResponse, find_notes
+from anki_mcp import FindNotesArgs, FindNotesResponse
+from anki_mcp.tools.notes import find_notes
 
 
 def test_find_notes_with_limit_and_offset(monkeypatch):

--- a/tests/test_list_models.py
+++ b/tests/test_list_models.py
@@ -43,11 +43,8 @@ ROOT = Path(__file__).resolve().parent.parent
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from server import (  # noqa: E402
-    ListModelsResponse,
-    ModelSummary,
-    list_models,
-)
+from anki_mcp import ListModelsResponse, ModelSummary  # noqa: E402
+from anki_mcp.tools.models import list_models  # noqa: E402
 
 
 def _unwrap_tool(func):

--- a/tests/test_list_tags.py
+++ b/tests/test_list_tags.py
@@ -41,10 +41,8 @@ ROOT = Path(__file__).resolve().parent.parent
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from server import (  # noqa: E402
-    ListTagsResponse,
-    list_tags,
-)
+from anki_mcp import ListTagsResponse  # noqa: E402
+from anki_mcp.tools.decks import list_tags  # noqa: E402
 
 
 def _unwrap_tool(func):

--- a/tests/test_media_tools.py
+++ b/tests/test_media_tools.py
@@ -42,7 +42,8 @@ ROOT = Path(__file__).resolve().parent.parent
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from server import DeleteMediaArgs, MediaRequest, delete_media, get_media  # noqa: E402
+from anki_mcp import DeleteMediaArgs, MediaRequest  # noqa: E402
+from anki_mcp.tools.media import delete_media, get_media  # noqa: E402
 
 
 def _unwrap(tool):

--- a/tests/test_note_info.py
+++ b/tests/test_note_info.py
@@ -89,7 +89,8 @@ ROOT = Path(__file__).resolve().parent.parent
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from server import NoteInfoArgs, NoteInfoResponse, note_info
+from anki_mcp import NoteInfoArgs, NoteInfoResponse
+from anki_mcp.tools.notes import note_info
 
 
 def test_note_info_normalizes_payload(monkeypatch):

--- a/tests/test_notes_to_cards.py
+++ b/tests/test_notes_to_cards.py
@@ -92,7 +92,8 @@ ROOT = Path(__file__).resolve().parent.parent
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from server import NotesToCardsArgs, NotesToCardsResponse, notes_to_cards
+from anki_mcp import NotesToCardsArgs, NotesToCardsResponse
+from anki_mcp.tools.notes import notes_to_cards
 
 
 def test_notes_to_cards_normalizes_response(monkeypatch):

--- a/tests/test_sources_autolink.py
+++ b/tests/test_sources_autolink.py
@@ -41,7 +41,8 @@ ROOT = Path(__file__).resolve().parent.parent
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from server import AddNotesArgs, NoteInput, add_from_model, add_notes
+from anki_mcp import AddNotesArgs, NoteInput
+from anki_mcp.tools.notes import add_from_model, add_notes
 
 
 @pytest.fixture

--- a/tests/test_store_media.py
+++ b/tests/test_store_media.py
@@ -41,7 +41,8 @@ ROOT = Path(__file__).resolve().parent.parent
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from server import StoreMediaArgs, store_media  # noqa: E402
+from anki_mcp import StoreMediaArgs  # noqa: E402
+from anki_mcp.tools.media import store_media  # noqa: E402
 
 
 def _unwrap(tool):

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -40,7 +40,7 @@ ROOT = Path(__file__).resolve().parent.parent
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from server import sync  # noqa: E402
+from anki_mcp.tools.sync import sync  # noqa: E402
 
 
 def _unwrap(tool):

--- a/tests/test_update_model_styling.py
+++ b/tests/test_update_model_styling.py
@@ -40,10 +40,8 @@ ROOT = Path(__file__).resolve().parent.parent
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from server import (  # noqa: E402
-    UpdateModelStylingArgs,
-    update_model_styling,
-)
+from anki_mcp import UpdateModelStylingArgs  # noqa: E402
+from anki_mcp.tools.models import update_model_styling  # noqa: E402
 
 
 def _unwrap(tool):

--- a/tests/test_update_model_templates.py
+++ b/tests/test_update_model_templates.py
@@ -40,11 +40,8 @@ ROOT = Path(__file__).resolve().parent.parent
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from server import (  # noqa: E402
-    CardTemplateSpec,
-    UpdateModelTemplatesArgs,
-    update_model_templates,
-)
+from anki_mcp import CardTemplateSpec, UpdateModelTemplatesArgs  # noqa: E402
+from anki_mcp.tools.models import update_model_templates  # noqa: E402
 
 
 def _unwrap(tool):

--- a/tests/test_update_notes.py
+++ b/tests/test_update_notes.py
@@ -42,12 +42,8 @@ ROOT = Path(__file__).resolve().parent.parent
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from server import (  # noqa: E402  # pylint: disable=wrong-import-position
-    ImageSpec,
-    NoteUpdate,
-    UpdateNotesArgs,
-    update_notes,
-)
+from anki_mcp import ImageSpec, NoteUpdate, UpdateNotesArgs  # noqa: E402  # pylint: disable=wrong-import-position
+from anki_mcp.tools.notes import update_notes  # noqa: E402  # pylint: disable=wrong-import-position
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- extract the former monolithic Anki tool module into themed modules for models, decks, notes, media and sync, colocating helper utilities
- update the tools package init to re-export the same public API from the new modules
- adjust tests to import tools from their new modules and validate the refactored structure

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d06de9d5508330977fbba4d776bace